### PR TITLE
Fix incorrect variable name

### DIFF
--- a/src/nwsapi.js
+++ b/src/nwsapi.js
@@ -346,7 +346,7 @@
       k = ident.length;
       m = method[type];
       for (i = 0; k > i; ++i) {
-        elms = context[m](ident[i]);
+        els = context[m](ident[i]);
         if (!els) continue; test = toArray(els);
         for (j = 0, c = 0; l > j; ++j) {
           if (list[j] === test[c]) { ++c; }


### PR DESCRIPTION
The `els` variable in the validate()-method was incorrectly referred to as `elms` in one location. This change fixes a few of the failures I saw in https://github.com/dperini/nwsapi/issues/10#issuecomment-382864103, though not all of them.