### PR TITLE
Set LIVECACHE=false as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Returns an array of elements having the specified class name `class`, optionally
 The following is the list of currently available configuration options, their default values and descriptions, they are boolean flags that can be set to `true` or `false`:
 
 * `IDS_DUPES`: true  - true to allow using multiple elements having the same id, false to disallow
-* `LIVECACHE`: true  - true for caching both results and resolvers, false for caching only resolvers
+* `LIVECACHE`: false - true for caching both results and resolvers, false for caching only resolvers
 * `MIXEDCASE`: true  - true to match tag names case insensitive, false to match using case sensitive
 * `LOGERRORS`: true  - true to print errors and warnings to the console, false to mute both of them
 

--- a/src/nwsapi.js
+++ b/src/nwsapi.js
@@ -126,7 +126,7 @@
   // special handling configuration flags
   Config = {
     IDS_DUPES: true,
-    LIVECACHE: true,
+    LIVECACHE: false,
     MIXEDCASE: true,
     LOGERRORS: true,
     VERBOSITY: true


### PR DESCRIPTION
A recent change in nwsapi breaks jsdom : 

When you do repetitive selections in the DOM until an element appears, since the LIVECACHE is now true by default, the element will never appear. The commit that introduced this change is 639efc5a827ef08fb7ebdc96401985411eca3400. This commit is present in 2.1.0 (which does not work), and not present in 2.0.9 (which does work).

It would also be possible to update jsdom to add that option in the nwsapi configuration, but to be "semver-compliant", minor releases should not add an option that defaults to a value that breaks the standard usecase.

This is why I set LIVECACHE to false by default.

Can you merge this and publish a patch release ?

Thanks