### PR TITLE
fix: support repeated :scope

### DIFF
--- a/src/nwsapi.js
+++ b/src/nwsapi.js
@@ -1324,7 +1324,7 @@
   // replace ':scope' pseudo-class with element references
   makeref =
     function(selectors, element) {
-      return selectors.replace(/:scope/i,
+      return selectors.replace(/:scope/ig,
         element.nodeName.toLowerCase() +
         (element.id ? '#' + element.id : '') +
         (element.className ? '.' + element.classList[0] : ''));

--- a/test/scope/scope-03b.html
+++ b/test/scope/scope-03b.html
@@ -15,6 +15,7 @@
   var aNode = NW.Dom.first('.a')
   var entriesUnscoped = NW.Dom.select('body div', aNode);
   var entriesScoped = NW.Dom.select(':scope body div', aNode);
+  var entriesMultipleScoped = NW.Dom.select(':scope > .a1, :scope > .a2', aNode);
 
   if (entriesUnscoped.length !== 2) {
     console.log('1. Invalid number of entries, should be 2, got ' + entriesUnscoped.length);
@@ -26,6 +27,12 @@
     console.log('2. Invalid number of entries, should be 0, got ' + entriesScoped.length);
   } else {
     console.log('2. Passed!');
+  }
+
+  if (entriesMultipleScoped.length !== 2) {
+    console.log('3. Invalid number of entries, should be 2, got ' + entriesScoped.length);
+  } else {
+    console.log('3. Passed!');
   }
 
 </script>


### PR DESCRIPTION
Avoids throw on selector with repeated :scope.
* nwsapi.js:  adjusts makeref() to replace all matches of :scope
instead of just the first match.
* scope03b.html: add test case

Fixes #33