### PR TITLE
Fix queries by tag name for elements in a non-default namespace.

### DIFF
--- a/src/nwsapi.js
+++ b/src/nwsapi.js
@@ -327,7 +327,7 @@
 
   method = {
     '#': 'getElementById',
-    '*': 'getElementsByTagName',
+    '*': 'getElementsByTagNameNS',
     '.': 'getElementsByClassName'
     },
 
@@ -383,18 +383,18 @@
       var e, nodes, api = method['*'];
       // DOCUMENT_NODE (9) & ELEMENT_NODE (1)
       if (api in context) {
-        return slice.call(context[api](tag));
+        return slice.call(context[api]("*", tag));
       } else {
         // DOCUMENT_FRAGMENT_NODE (11)
         if ((e = context.firstElementChild)) {
           tag = tag.toLowerCase();
           if (!(e.nextElementSibling || tag == '*' || e.nodeName.toLowerCase() == tag)) {
-            return slice.call(e[api](tag));
+            return slice.call(e[api]("*", tag));
           } else {
             nodes = [ ];
             do {
               if (tag == '*' || e.nodeName.toLowerCase() == tag) nodes[nodes.length] = e;
-              concatList(nodes, e[api](tag));
+              concatList(nodes, e[api]("*", tag));
             } while ((e = e.nextElementSibling));
           }
         } else nodes = none;

--- a/test/xml/xml-test.html
+++ b/test/xml/xml-test.html
@@ -8,17 +8,22 @@
 <body>
 <script>
 onload = function() {
-  var parser, string, dom, el;
+  var parser, string, dom, elNone, elStar, elPipe;
   parser = new window.DOMParser();
   string = '<?xml version="1.0"?><cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/"><dc:title></dc:title></cp:coreProperties>';
   dom = parser.parseFromString(string, 'text/xml');
-  el = dom.querySelectorAll('coreProperties');
-  if (el.length === 1) {
+  elNone = dom.querySelectorAll('coreProperties');
+  elStar = dom.querySelectorAll('*|coreProperties');
+  elPipe = dom.querySelectorAll('|coreProperties');
+
+  if (elNone.length === 1 && elStar.length === 1 && elPipe.length === 0) {
     console.log('Passed!');
   } else {
     console.log('Failed!');
   }
-  console.log(el);
+  console.log("elNone:", elNone);
+  console.log("elStar:", elStar);
+  console.log("elPipe:", elPipe);
 };
 </script>
 


### PR DESCRIPTION
Should fix:
https://github.com/dperini/nwsapi/issues/5
https://github.com/jsdom/jsdom/issues/1587
https://github.com/jsdom/jsdom/issues/2159

I don't think I've run all the relevant tests as I couldn't really figure out how. But this patch makes no difference to the w3c-selector-test results afaict.