### PR TITLE
add support for CSS pseudo elements - use CSSPseudoElement interface

### DIFF
--- a/src/nwsapi.js
+++ b/src/nwsapi.js
@@ -1235,14 +1235,18 @@
 
             // allow pseudo-elements starting with single colon (:)
             // :after, :before, :first-letter, :first-line
+            // assert: e.type is in double-colon format, like ::after
             else if ((match = selector.match(Patterns.pseudo_sng))) {
-              source = 'if(' + D + '(e.nodeType==1)){' + source + '}';
+              source = 'if(e.element&&e.type.toLowerCase()=="' +
+              ':' + match[0].toLowerCase() + '"){e=e.element;' + source + '}';
             }
 
             // allow pseudo-elements starting with double colon (::)
             // ::after, ::before, ::marker, ::placeholder, ::inactive-selection, ::selection, ::-webkit-<foo-bar>
+            // assert: e.type is in double-colon format, like ::after
             else if ((match = selector.match(Patterns.pseudo_dbl))) {
-              source = 'if(' + D + '(e.nodeType==1)){' + source + '}';
+              source = 'if(e.element&&e.type.toLowerCase()=="' +
+              match[0].toLowerCase() + '"){e=e.element;' + source + '}';
             }
 
             else {

--- a/src/nwsapi.js
+++ b/src/nwsapi.js
@@ -867,9 +867,9 @@
             }
             type = match[5] == 'i' || (HTML_DOCUMENT && HTML_TABLE[expr.toLowerCase()]) ? 'i' : '';
             source = 'if(' + N + '(' +
-              (!match[2] ? (NS ? 's.hasAttributeNS(e,"' + name + '")' : 'e.hasAttribute("' + name + '")') :
-              !match[4] && ATTR_STD_OPS[match[2]] && match[2] != '~=' ? 'e.getAttribute("' + name + '")==""' :
-              '(/' + test.p1 + match[4] + test.p2 + '/' + type + ').test(e.getAttribute("' + name + '"))==' + test.p3) +
+              (!match[2] ? (NS ? 's.hasAttributeNS(e,"' + name + '")' : 'e.hasAttribute&&e.hasAttribute("' + name + '")') :
+              !match[4] && ATTR_STD_OPS[match[2]] && match[2] != '~=' ? 'e.getAttribute&&e.getAttribute("' + name + '")==""' :
+              '(/' + test.p1 + match[4] + test.p2 + '/' + type + ').test(e.getAttribute&&e.getAttribute("' + name + '"))==' + test.p3) +
               ')){' + source + '}';
             break;
 


### PR DESCRIPTION

use the CSSPseudoElement interface
https://drafts.csswg.org/css-pseudo-4/#csspseudoelement

```webidl
interface CSSPseudoElement : EventTarget {
    readonly attribute CSSOMString type;
    readonly attribute Element element;
};
```

so in [jsdom](https://github.com/jsdom/jsdom/issues/1928) we can avoid workarounds like special `e.nodeType` values

`e.type` includes colons, like `:before` or `::before`

```js
Boolean(e.element)
```

has the highest selectivity
only pseudo elements have the element attribute
proof:

```
$ grep -E 'attribute .* element;' *.webidl
CSSPseudoElement.webidl:    readonly attribute Element element;
```

i expect when `e.element` is set, then also `e.type` is set

browser support for the CSSPseudoElement interface is virtually zero
only firefox has it, when in `about:config` you set
`dom.css_pseudo_element.enabled = true`
(not working for me)
https://developer.mozilla.org/en-US/docs/Web/API/CSSPseudoElement
https://developer.mozilla.org/en-US/docs/Web/API/CSSPseudoElement/element#Examples
