### PR TITLE
Rearrange useraction group to match `focus-within` before `focus`

### DIFF
--- a/src/nwsapi.js
+++ b/src/nwsapi.js
@@ -82,7 +82,7 @@
     treestruct: '(nth(?:-last)?(?:-child|-of-type))(?:\\x28\\s?(even|odd|(?:[-+]?\\d*)(?:n\\s?[-+]?\\s?\\d*)?)\\s?(?:\\x29|$))',
     // pseudo-classes not requiring parameters
     locationpc: '(any-link|link|visited|target)\\b',
-    useraction: '(hover|active|focus|focus-within)\\b',
+    useraction: '(hover|active|focus-within|focus)\\b',
     structural: '(root|empty|(?:(?:first|last|only)(?:-child|-of-type)))\\b',
     inputstate: '(enabled|disabled|read-only|read-write|placeholder-shown|default)\\b',
     inputvalue: '(checked|indeterminate|required|optional|valid|invalid|in-range|out-of-range)\\b',


### PR DESCRIPTION
Currently a style with `:focus-within` ends as `:focus` + `-within` generating incorrect rule

The code before was producing for something like
```
.class1:focus-within .class2
```
something like 
```
(function anonymous(s) {
"use strict";return function Resolver(c,f,x,r){var e,n,o;e=c;if((e.nodeName.toLowerCase()=="focus")){if((e===s.doc.activeElement&&s.doc.hasFocus()&&(e.type||e.href||typeof e.tabIndex=="number"))){if((/(^|\s)eGeHBG(\s|$)/.test(e.getAttribute("class")))){r=true;}}}return r;}
})
```
Where `e.nodeName.toLowerCase()=="focus"` is definitely not what expected
