### PR TITLE
fix: bypass descendant combinator typeerror

### DIFF
--- a/src/nwsapi.js
+++ b/src/nwsapi.js
@@ -901,7 +901,7 @@
           case '\x09':
           case '\x20':
             match = selector.match(Patterns.ancestor);
-            source = 'n=e;while((e=e.parentElement)){' + source + '}e=n;';
+            source = 'n=e;while(e && (e=e.parentElement)){' + source + '}e=n;';
             break;
           // *** Child combinator
           // E > F (F children of E)


### PR DESCRIPTION
### Motivation and context:
The nwsapi parsing gives TypeError in cases like below:
```css
  &:disabled {
      svg path {
          fill: var(--color-brand-primary)
      } 
  }
```

> ![image](https://user-images.githubusercontent.com/62719703/216369958-41c36388-c6fb-418f-a0cc-23b6880f0537.png)
> TypeError:  Cannot read properties of null (reading 'parentElement')

This change checks for null value when parsing the `Descendant combinator`, and can potentially bypass TypeErrors like in #75 