### PR TITLE
fix attribute selector with string escape

### DIFF
--- a/src/nwsapi.js
+++ b/src/nwsapi.js
@@ -852,12 +852,12 @@
                 { p1: '^\\s', p2: '+$', p3: 'true' } :
                   match[2] in ATTR_STD_OPS && match[2] != '~=' ?
                 { p1: '^',    p2: '$',  p3: 'true' } : test;
-            } else if (match[2] == '~=' && match[4].includes(' ')) {
-              // whitespace separated list but value contains space
-              source = 'if(' + N + 'false){' + source + '}';
-              break;
             } else if (match[4]) {
               match[4] = convertEscapes(match[4]).replace(REX.RegExpChar, '\\$&');
+              if (match[2] == '~=' && match[4].includes(' ')) {
+                source = 'if(' + N + 'false){' + source + '}';
+                break;
+              }
             }
             type = match[5] == 'i' || (HTML_DOCUMENT && HTML_TABLE[expr.toLowerCase()]) ? 'i' : '';
             source = 'if(' + N + '(' +


### PR DESCRIPTION
fixes #84

test plan: edited

```diff
diff --git a/test/css3-compat/css3-compat.html b/test/css3-compat/css3-compat.html
index 966bc30..0ec60aa 100644
--- a/test/css3-compat/css3-compat.html
+++ b/test/css3-compat/css3-compat.html
@@ -46,7 +46,7 @@
     .blox6[\_foo="\e9"] { background-color: lime; }

     /* test 4 : [~=] */
-    .blox7[class~="foo"] { background-color: lime; }
+    .blox7[class~="f\6f o"] { background-color: lime; }
     .blox8, .blox9, .blox10 { background-color: lime; }
     .blox8[class~=""] { background-color: red; }
     .blox9[foo~=""] { background-color: red; }
```

and verified that all boxes are green (with both querySelectorAll and nwsapi)