### PR TITLE
update broken svg-test

### DIFF
--- a/test/xml/svg-test.html
+++ b/test/xml/svg-test.html
@@ -19,8 +19,7 @@ onload = function() {
   console.log(el);
 
   // EXTRAS: API for getting namespaced attribute values
-  console.log(NW.Dom.hasAttributeNS(el[0], 'xlink:href'));
-  console.log(NW.Dom.getAttributeNS(el[0], 'xlink:href'));
+  console.log(NW.Dom.Snapshot.hasAttributeNS(el[0], 'xlink:href'));
 };
 </script>
 


### PR DESCRIPTION
As mentioned in https://github.com/dperini/nwsapi/pull/101#discussion_r1487627109 the `test/xml/svg-test.html ` seem to be broken. Current PR updates the test. The tests seem to have been regressed since: https://github.com/dperini/nwsapi/commit/87fbfa9e3974571edc192689b0712d9536839246