### PR TITLE
fix: prevent `SyntaxError` while parsing `:has` pseudo selectors

### DIFF
--- a/src/nwsapi.js
+++ b/src/nwsapi.js
@@ -1026,7 +1026,7 @@
                 case 'has':
                   referenceElement = selector_string.split(':')[0];
                   expr = match[2].replace(REX.CommaGroup, ',').replace(REX.TrimSpaces, '');
-                  source = 'if(s.match("' + referenceElement + '",e) && e.querySelector("'+ expr.replace(/\x22/g, '\\"') +'")){' + source + '}';
+                  source = 'if(s.match("' + referenceElement.replace(/\x22/g, '\\"') + '",e) && e.querySelector("'+ expr.replace(/\x22/g, '\\"') +'")){' + source + '}';
                   break;
                 default:
                   emit('\'' + selector_string + '\'' + qsInvalid);

--- a/test/w3c/dom/nodes/Element-closest.html
+++ b/test/w3c/dom/nodes/Element-closest.html
@@ -43,6 +43,7 @@
   do_test("div#test7"                  , "test1" , "test7");
 
   do_test(".div3 > .div2"              , "test12", "test7");
+  do_test("[class=\"div2\"]:has(div)"  , "test12", "test7");
   do_test(".div3 > .div1"              , "test12", "");
   do_test("form > input[required]"     , "test9" , "");
   do_test("fieldset > select[required]", "test12", "test3");


### PR DESCRIPTION
Fix for issue #111 