### PR TITLE
Fix content editable :read-write detection

### DIFF
--- a/src/nwsapi.js
+++ b/src/nwsapi.js
@@ -1162,7 +1162,7 @@
                     'if((' +
                       '((/^textarea$/i.test(e.localName)&&!e.readOnly&&!e.disabled)||' +
                       '("|date|datetime-local|email|month|number|password|search|tel|text|time|url|week|".includes("|"+e.type+"|")&&!e.readOnly&&!e.disabled))||' +
-                      '(e.hasAttribute("contenteditable")||(s.doc.designMode=="on"))' +
+                      '((e.hasAttribute("contenteditable")&&e.getAttribute("contenteditable")!="false")||(s.doc.designMode=="on"))' +
                     ')){' + source + '}';
                   break;
                 case 'placeholder-shown':


### PR DESCRIPTION
Currently `[contenteditable]:read-write` will detect an element like `<div contenteditable="false"></div>`, this is incorrect and now how browsers currently work.

This fixes that bug by ensuring the attribute is not equal to false & bumps the version.