### PR TITLE
fix: ensure toNodeList uses doc var

### DIFF
--- a/src/nwsapi.js
+++ b/src/nwsapi.js
@@ -212,7 +212,7 @@
   toNodeList =
     function() {
       // create a DocumentFragment
-      var emptyNL = document.createDocumentFragment().childNodes;
+      var emptyNL = doc.createDocumentFragment().childNodes;
 
       // this is returned from a self-executing function so that
       // the DocumentFragment isn't repeatedly created.


### PR DESCRIPTION
## Overview
The latest release has broken our esbuild compilation where we use this package via the esbuild-html-plugin, running in Node.js. As such this fix should ensure `global.document` is used in the recently added `toNodeList` method and prevent the runtime error we're seeing:

```
node_modules/nwsapi/src/nwsapi.js:215:20: ERROR: [plugin: esbuild-html-plugin] document is not defined
```

Closes #135
Closes #136 