### PR TITLE
Fix JSDOM interaction with querySelectorAll

### DIFF
--- a/src/nwsapi.js
+++ b/src/nwsapi.js
@@ -1113,7 +1113,7 @@
                   break;
                 case 'has':
                          if (/^\s*[+]/.test(match[2])) {
-                    source = 'if((e.parentElement.querySelectorAll("*' + expr.replace(/\x22/g, '\\"') + '")).includes(e.nextElementSibling)){' + source + '}';
+                    source = 'if(e.parentElement && [].slice.call(e.parentElement.querySelectorAll("*' + expr.replace(/\x22/g, '\\"') + '")).includes(e.nextElementSibling)){' + source + '}';
                   } else if (/^\s*[~]/.test(match[2])) {
                     source = 'if([].slice.call(e.parentElement.children).includes(e.nextElementSibling)){' + source + '}';
                   } else { 


### PR DESCRIPTION
The following code fails with
TypeError: e.parentElement.querySelectorAll(...).includes is not a function

```javascript
const { JSDOM } = require("jsdom");
const dom = new JSDOM(`<div>
  <span>first</span>
  <span>second</span>
<div>`);

dom.window.document.querySelector("span:has(+ span)");
```

The problem is that JSDOM uses its own patched version of `querySelectorAll`, which returns a `NodeList`. nwsapi instead returns an `Array`, which means that the use of querySelectorAll(...).includes in the relative sibling selector works.