### PR TITLE
fix: check for existence of e.parentElement before accessing children

### DIFF
--- a/src/nwsapi.js
+++ b/src/nwsapi.js
@@ -1120,7 +1120,7 @@
                          if (/^\s*[+]/.test(match[2])) {
                     source = 'if(e.parentElement && [].slice.call(e.parentElement.querySelectorAll("*' + expr.replace(/\x22/g, '\\"') + '")).includes(e.nextElementSibling)){' + source + '}';
                   } else if (/^\s*[~]/.test(match[2])) {
-                    source = 'if([].slice.call(e.parentElement.children).includes(e.nextElementSibling)){' + source + '}';
+                    source = 'if(e.parentElement && [].slice.call(e.parentElement.children).includes(e.nextElementSibling)){' + source + '}';
                   } else {
                     source = 'if(e.querySelector(":scope ' + expr.replace(/\x22/g, '\\"') + '")){' + source + '}';
                   }


### PR DESCRIPTION
Check for existence of `e.parentElement` before accessing `e.parentElement.children`.

fixes #145
