### PR TITLE
Updated `pseudo-nop` regex to generically capture all vendor extensions as no-op selectors.

### DIFF
--- a/src/nwsapi.js
+++ b/src/nwsapi.js
@@ -91,7 +91,7 @@
     disp_state: '(open|closed|modal|fullscreen|picture-in-picture)\\b',
     time_state: '(current|past|future)\\b',
     // pseudo-classes for parsing only selectors
-    pseudo_nop: '(autofill|-webkit\\-autofill|-moz\\-read\\-only)\\b',
+    pseudo_nop: '(autofill|-webkit\\-autofill|[-](?:webkit|moz|op|ms)(?:[-][a-zA-Z0-9]{2,})+)\\b',
     // pseudo-elements starting with single colon (:)
     pseudo_sng: '(after|before|first\\-letter|first\\-line)\\b',
     // pseudo-elements starting with double colon (::)

--- a/src/nwsapi.js
+++ b/src/nwsapi.js
@@ -91,7 +91,7 @@
     disp_state: '(open|closed|modal|fullscreen|picture-in-picture)\\b',
     time_state: '(current|past|future)\\b',
     // pseudo-classes for parsing only selectors
-    pseudo_nop: '(autofill|-webkit\\-autofill)\\b',
+    pseudo_nop: '(autofill|-webkit\\-autofill|-moz\\-read\\-only)\\b',
     // pseudo-elements starting with single colon (:)
     pseudo_sng: '(after|before|first\\-letter|first\\-line)\\b',
     // pseudo-elements starting with double colon (::)


### PR DESCRIPTION
- Fixes #150
- As it says on the tin.
- All pseudo-class selectors prefixed with a vendor extension will now be captured as a no-op selector.
- This resolves an observed issue of unmatched selectors (e.g. `-moz-read-only`) failing to parse and throwing an error, thereby failing test execution.