### PR TITLE
Fix repository URL protocol

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/dperini/nwsapi.git"
+    "url": "https://github.com/dperini/nwsapi.git"
   },
   "scripts": {
     "lint": "eslint ./src/nwsapi.js"


### PR DESCRIPTION
This updates the package metadata repository URL from the legacy `git://` protocol to HTTPS.

The `git://` protocol is unauthenticated and may be blocked on some networks, while the HTTPS GitHub URL is directly accessible to npm users and tooling.

Validation:
- Parsed `package.json` and asserted `repository.url`
- `git diff --check`
- `npm install --ignore-scripts`

Note: `npm run lint` is currently not runnable from a clean install because `eslint` is not declared as a dependency. I also tried a temporary no-save `eslint@8.57.1` install; it fails on existing source with `Parsing error: Assigning to rvalue` in `src/nwsapi.js`, unrelated to this package metadata change.