### PR TITLE
Fix :has() sibling matching at root elements

### DIFF
--- a/src/nwsapi.js
+++ b/src/nwsapi.js
@@ -1297,9 +1297,9 @@
                   t = expr.charAt(0);
 
                   if (t == '+') {
-                    source  = 'if(s.select("*' + expr + '",e.parentElement).includes(e.nextElementSibling)){' + source + '}';
+                    source  = 'if(e.parentElement&&s.select("*' + expr + '",e.parentElement).includes(e.nextElementSibling)){' + source + '}';
                   } else if (t == '~') {
-                    source  = 'if(Array.from(e.parentElement.children).includes(e.nextElementSibling)){' + source + '}';
+                    source  = 'if(e.parentElement&&Array.from(e.parentElement.children).includes(e.nextElementSibling)){' + source + '}';
                   } else if (t == '>') {
                     source = 'if(s.first(":scope ' + expr + '",e)){' + source + '}';
                   } else {

--- a/test/has-sibling-root.html
+++ b/test/has-sibling-root.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>NWSAPI :has() sibling root regression</title>
+</head>
+<body>
+
+<div class="subject"><span id="target" class="target"></span></div>
+<div class="sibling"></div>
+
+<script src="../src/nwsapi.js"></script>
+<script>
+var cases = [
+  [document.documentElement, ':has(+ p)', false],
+  [document.documentElement, ':has(~ p)', false],
+  [document.getElementById('target'), '.subject:has(~ .sibling) .target', true]
+];
+
+cases.forEach(function(test) {
+  var actual = NW.Dom.match(test[1], test[0]);
+  if (actual !== test[2]) {
+    throw new Error(test[1] + ': expected ' + test[2] + ', received ' + actual);
+  }
+});
+
+document.body.setAttribute('data-result', 'pass');
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
Fixes #168.

This restores the `parentElement` guard before compiling adjacent- and general-sibling relational selectors inside `:has()`. Without it, matching a compound selector can reach the document root and dereference its null parent.

The new browser regression test covers both sibling forms at the root and a positive compound-selector case.

Validation:

- `node --check src/nwsapi.js`
- direct patched-source checks: root adjacent `false`, root general sibling `false`, compound sibling `true`
- `test/has-sibling-root.html` under JSDOM: `data-result=pass`, no script errors
- Ant Design #59151 exact head: released 2.2.25 fails 6/55 affected Tooltip tests; this local package passes 55/55 with 5 snapshots
- `git diff --check`

The repository's current ESLint configuration reports 185 pre-existing errors across `src/nwsapi.js` when run with ES6 parsing; this patch does not introduce a new lint rule or broad cleanup.

AI assistance disclosure: Codex was used to trace and minimize the regression, prepare the focused patch and regression test, and draft this description. I reviewed the diff and reproduced all validation locally.
