### PR TITLE
Prevent recursive state pseudo-class matching in jsdom

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,10 @@
     "url": "https://github.com/dperini/nwsapi.git"
   },
   "scripts": {
-    "lint": "eslint ./src/nwsapi.js"
+    "lint": "eslint ./src/nwsapi.js",
+    "test": "node ./test/jsdom-state-pseudo-classes.js"
+  },
+  "devDependencies": {
+    "jsdom": "20.0.3"
   }
 }

--- a/src/nwsapi.js
+++ b/src/nwsapi.js
@@ -702,17 +702,22 @@
       return false;
     },
 
+  nativeMatchActive = false,
+
   // use the native selector state when it is available; when NWSAPI has
   // installed itself, _matches retains the native implementation
   matchesNative =
     function(node, selector) {
       var matcher = _matches || node.matches || node.webkitMatchesSelector ||
         node.mozMatchesSelector || node.msMatchesSelector;
-      if (!matcher) return false;
+      if (!matcher || nativeMatchActive) return false;
       try {
+        nativeMatchActive = true;
         return matcher.call(node, selector);
       } catch (e) {
         return false;
+      } finally {
+        nativeMatchActive = false;
       }
     },
 

--- a/test/jsdom-state-pseudo-classes.js
+++ b/test/jsdom-state-pseudo-classes.js
@@ -1,0 +1,52 @@
+"use strict";
+
+const assert = require("assert");
+const Module = require("module");
+const nwsapi = require("../src/nwsapi");
+
+const load = Module._load;
+Module._load = function(request, parent, isMain) {
+  return request == "nwsapi" ? nwsapi : load(request, parent, isMain);
+};
+
+const { JSDOM } = require("jsdom");
+Module._load = load;
+
+const dom = new JSDOM("<div></div>");
+const element = dom.window.document.querySelector("div");
+const matches = dom.window.Element.prototype.matches;
+let calls = 0;
+
+dom.window.Element.prototype.matches = function(selector) {
+  ++calls;
+  if (calls > 10) {
+    throw new Error("Element.matches recursively entered NWSAPI");
+  }
+  return matches.call(this, selector);
+};
+
+[
+  ":modal",
+  ":fullscreen",
+  ":open",
+  ":closed",
+  ":picture-in-picture"
+].forEach(function(selector) {
+  calls = 0;
+  assert.strictEqual(element.matches(selector), false);
+  assert.ok(calls <= 3, selector + " recursively entered NWSAPI");
+});
+
+const matcher = nwsapi({
+  document: dom.window.document,
+  DOMException: dom.window.DOMException
+});
+let nativeCalls = 0;
+
+element.matches = function(selector) {
+  ++nativeCalls;
+  return selector == ":modal";
+};
+
+assert.strictEqual(matcher.match(":modal", element), true);
+assert.strictEqual(nativeCalls, 1);


### PR DESCRIPTION
## Summary

- prevent native state detection from re-entering the same NWSAPI instance
- preserve delegation to genuine native `Element.matches()` implementations
- add a deterministic jsdom regression test for the affected state pseudo-classes

## Problem

The native state detection added in 2.2.26 assumes that `node.matches` is a browser-native implementation when `_matches` is unavailable. In jsdom, `Element.matches()` delegates back to NWSAPI:

```text
element.matches(":modal")
→ jsdom ElementImpl.matches()
→ nwsapi.match(":modal")
→ isModal()
→ matchesNative(":modal")
→ element.matches(":modal")
→ ...
```

The resulting `RangeError` is caught by `matchesNative()`, so callers receive the expected `false` result, but only after the JavaScript call stack has been exhausted. `:modal` also falls through to `isFullscreen()`, which exercises the same recursive path.

This becomes especially expensive for consumers such as Floating UI that call `element.matches(":modal")` repeatedly while positioning elements. In a jsdom reproduction that performs 100 `:modal` checks:

- nwsapi 2.2.25: approximately 0.32 seconds
- nwsapi 2.2.26: approximately 29.19 seconds
- nwsapi 2.2.27: approximately 29.19 seconds

The guard in this change only suppresses re-entrant native matching. A genuine native matcher remains the first source of truth.

## Testing

- `npm test`
- regression test verified to fail against current upstream `master`
- regression test passes on Node.js 14 and Node.js 26
- `git diff --check`