### PR TITLE
JSDOM recursion fix

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,27 +3,26 @@ name: nwsapi
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
-  test:
+  build:
     runs-on: ubuntu-latest
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7
+      uses: actions/checkout@v2
 
     - name: Setup Node.js
-      uses: actions/setup-node@v7
+      uses: actions/setup-node@v2
       with:
-        node-version: latest
-        package-manager-cache: false
+        node-version: '14'
 
     - name: Install dependencies
       run: npm install
 
     - name: Run tests
-      run: npm test
+      run: npm testIs the NodeJS yaml configuration needed in my "nwsapi" repository ?

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,26 +3,27 @@ name: nwsapi
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
-      - main
+      - master
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v7
 
     - name: Setup Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v7
       with:
-        node-version: '14'
+        node-version: latest
+        package-manager-cache: false
 
     - name: Install dependencies
       run: npm install
 
     - name: Run tests
-      run: npm testIs the NodeJS yaml configuration needed in my "nwsapi" repository ?
+      run: npm test

--- a/package.json
+++ b/package.json
@@ -38,6 +38,15 @@
     "url": "https://github.com/dperini/nwsapi.git"
   },
   "scripts": {
-    "lint": "eslint ./src/nwsapi.js"
+    "lint": "eslint ./src/nwsapi.js",
+    "test": "jest --runInBand"
+  },
+  "devDependencies": {
+    "jest": "30.4.2"
+  },
+  "jest": {
+    "testMatch": [
+      "<rootDir>/test/**/*.test.js"
+    ]
   }
 }

--- a/src/nwsapi.js
+++ b/src/nwsapi.js
@@ -24,17 +24,21 @@
   } else if (typeof define == 'function' && define['amd']) {
     define(factory);
   } else {
+    var proto = global.Element && global.Element.prototype;
     global.NW || (global.NW = { });
-    global.NW.Dom = factory(global, Export);
+    global.NW.Dom = factory(global, Export, proto && (
+      proto.matches || proto.webkitMatchesSelector ||
+      proto.mozMatchesSelector || proto.msMatchesSelector));
   }
 
-})(this, function Factory(global, Export) {
+})(this, function Factory(global, Export, platformMatches) {
 
   var version = 'nwsapi-2.2.27',
 
   doc = global.document,
   root = doc.documentElement,
   slice = Array.prototype.slice,
+  nativeMatcher = typeof platformMatches == 'function' ? platformMatches : null,
 
   HSP = '\\x20\\t',
   VSP = '\\r\\n\\f',
@@ -702,19 +706,20 @@
       return false;
     },
 
-  // use the native selector state when it is available; when NWSAPI has
-  // installed itself, _matches retains the native implementation
+  // use only the platform matcher captured when the factory was created;
+  // node.matches may itself delegate to this NWSAPI instance
   matchesNative =
-    function(node, selector) {
-      var matcher = _matches || node.matches || node.webkitMatchesSelector ||
-        node.mozMatchesSelector || node.msMatchesSelector;
-      if (!matcher) return false;
-      try {
-        return matcher.call(node, selector);
-      } catch (e) {
+    nativeMatcher ?
+      function(node, selector) {
+        try {
+          return nativeMatcher.call(node, selector);
+        } catch (e) {
+          return false;
+        }
+      } :
+      function() {
         return false;
-      }
-    },
+      },
 
   // :open and :closed have a portable DOM state for details and dialog.
   // Native matching extends support to host-language states such as pickers.

--- a/test/display-state-native-matches.test.js
+++ b/test/display-state-native-matches.test.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const createNwsapi = require('../src/nwsapi.js');
+
+function createGlobal() {
+  const documentElement = {
+    namespaceURI: 'http://www.w3.org/1999/xhtml'
+  };
+  const document = {
+    nodeType: 9,
+    contentType: 'text/html',
+    compatMode: 'CSS1Compat',
+    documentElement: documentElement,
+    addEventListener: function() { },
+    createElement: function(name) {
+      return { localName: name.toLowerCase() };
+    }
+  };
+
+  return {
+    document: document,
+    DOMException: Error,
+    NodeList: Array
+  };
+}
+
+function createElement(document) {
+  return {
+    nodeType: 1,
+    localName: 'div',
+    ownerDocument: document,
+    hasAttribute: function() { return false; }
+  };
+}
+
+describe('display-state native matching', function() {
+  test('does not call a module-backed Element#matches', function() {
+    const delegatedGlobal = createGlobal();
+    const delegatedDom = createNwsapi(delegatedGlobal);
+    const delegatedElement = createElement(delegatedGlobal.document);
+    const delegatedMatches = jest.fn(function(selector) {
+      return delegatedDom.match(selector, delegatedElement);
+    });
+
+    delegatedElement.matches = delegatedMatches;
+
+    [
+      ':open',
+      ':closed',
+      ':modal',
+      ':fullscreen',
+      ':picture-in-picture'
+    ].forEach(function(selector) {
+      expect(delegatedDom.match(selector, delegatedElement)).toBe(false);
+    });
+
+    delegatedElement.hasAttribute = function(name) {
+      return name == 'popover';
+    };
+    expect(delegatedDom.match(':popover-open', delegatedElement)).toBe(false);
+    expect(delegatedMatches).not.toHaveBeenCalled();
+  });
+
+  test('uses the platform matcher captured by the factory', function() {
+    const nativeGlobal = createGlobal();
+    const nativeMatcher = jest.fn(function(selector) {
+      return selector == ':fullscreen';
+    });
+    const nativeDom = createNwsapi(nativeGlobal, null, nativeMatcher);
+    const nativeElement = createElement(nativeGlobal.document);
+    const nodeMatcher = jest.fn(function() {
+      throw new Error('the node matcher must not be consulted');
+    });
+
+    nativeElement.matches = nodeMatcher;
+
+    expect(nativeDom.match(':fullscreen', nativeElement)).toBe(true);
+    expect(nativeMatcher).toHaveBeenCalledTimes(1);
+    expect(nativeMatcher).toHaveBeenCalledWith(':fullscreen');
+    expect(nodeMatcher).not.toHaveBeenCalled();
+  });
+
+  test('returns false when the captured platform matcher throws', function() {
+    const throwingGlobal = createGlobal();
+    const throwingMatcher = jest.fn(function() {
+      throw new Error('unsupported selector');
+    });
+    const throwingDom = createNwsapi(throwingGlobal, null, throwingMatcher);
+
+    expect(
+      throwingDom.match(':fullscreen', createElement(throwingGlobal.document))
+    ).toBe(false);
+    expect(throwingMatcher).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- capture the browser platform's `Element#matches` implementation once, before nwsapi can replace it
- prevent CommonJS and headless environments from dynamically delegating back through a module-backed `node.matches`
- add Jest regression coverage for all affected display-state pseudo-classes
- update GitHub Actions to run the Jest suite with the latest Node.js release and current action versions

## Problem

The native display-state detection introduced in nwsapi 2.2.26 assumes that `node.matches` is a native browser implementation when `_matches` is unavailable. In environments such as jsdom, `Element#matches` delegates back to the same nwsapi instance:

```text
element.matches(':modal')
-> nwsapi.match(':modal')
-> isModal()
-> matchesNative(':modal')
-> element.matches(':modal')
-> ...
```

The resulting stack overflow is caught by `matchesNative()`, so the caller eventually receives `false`, but only after substantial recursive work and CPU usage.

## Solution

Native matcher provenance is now established when the factory is created:

- the browser bootstrap captures the platform matcher from `Element.prototype`
- the captured matcher is passed into the nwsapi factory and retained in its closure
- `matchesNative()` calls only that trusted reference
- when no platform matcher is supplied, `matchesNative()` is initialized as a direct false-returning function

The helper no longer probes `node.matches` or its vendor-prefixed aliases during selector evaluation. A module-backed matcher therefore cannot be mistaken for a native implementation and called recursively.

CommonJS and headless embedders with a genuine platform matcher can supply it explicitly. Otherwise, nwsapi uses its existing observable DOM-state fallbacks.

## Why This Approach

A synchronous re-entrancy flag limits the recursion but still calls the module-backed matcher once for every outer state check. That causes an unnecessary round trip through the host and another nwsapi selector evaluation. It also adds repeated matcher discovery and mutable guard state to a hot path.

Capturing matcher provenance once removes the recursive route entirely:

- zero calls to a module-backed `Element#matches`
- no repeated matcher-chain lookup
- no `try/finally` re-entrancy bookkeeping
- no factory-wide flag that can suppress unrelated nested native matching
- one direct call when a trusted platform matcher is available

## Testing

The Jest regression suite verifies that:

- module-backed `Element#matches` is never called for `:open`, `:closed`, `:modal`, `:fullscreen`, `:picture-in-picture`, or `:popover-open`
- an explicitly supplied platform matcher is called exactly once
- an element-level matcher is not consulted when a platform matcher was captured
- exceptions from the platform matcher retain the existing `false` fallback

Validation performed:

```text
npm test
Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
```

The original jsdom 26.1.0 reproduction also completes without recursion.

## CI
The Node workflow now:

- runs on pushes and pull requests targeting the repository's `master` branch
- uses `actions/checkout@v7` and `actions/setup-node@v7`
- resolves the latest available Node.js release
- installs dependencies and executes `npm test`
