### PR TITLE
Fix the forgiving fallback and EOF-terminated arguments

### DIFF
--- a/src/nwsapi.js
+++ b/src/nwsapi.js
@@ -66,7 +66,8 @@
     FixEscapes: RegExp('\\\\([0-9a-fA-F]{1,6}' + WSP + '?|.)|([\\x22\\x27])', 'g'),
     CombineWSP: RegExp('[\\n\\r\\f\\x20]+' + NOT.single_enc + NOT.double_enc, 'g'),
     TabCharWSP: RegExp('(\\x20?\\t+\\x20?)' + NOT.single_enc + NOT.double_enc, 'g'),
-    PseudosWSP: RegExp('\\s+([-+])\\s+' + NOT.square_enc, 'g')
+    PseudosWSP: RegExp('\\s+([-+])\\s+' + NOT.square_enc, 'g'),
+    LogicalPfx: RegExp('^:(is|where|matches|not|has)\\x28', 'i')
   },
 
   STD = {
@@ -77,9 +78,9 @@
 
   GROUPS = {
     // pseudo-classes requiring parameters
-    linguistic: '(dir|lang)(?:\\x28\\s?([-\\w]{2,})\\s?\\x29)',
-    logicalsel: '(is|where|matches|not|has)(?:\\x28\\s?(' + '[^()]*|.*' + ')\\s?\\x29)',
-    treestruct: '(nth(?:-last)?(?:-child|-of\\-type))(?:\\x28\\s?(even|odd|(?:[-+]?\\d*)(?:n\\s?[-+]?\\s?\\d*)?)\\s?\\x29)',
+    linguistic: '(dir|lang)(?:\\x28\\s?([-\\w]{2,})\\s?(?:\\x29|$))',
+    logicalsel: '(is|where|matches|not|has)(?:\\x28\\s?(' + '[^()]*|.*' + ')\\s?(?:\\x29|$))',
+    treestruct: '(nth(?:-last)?(?:-child|-of\\-type))(?:\\x28\\s?(even|odd|(?:[-+]?\\d*)(?:n\\s?[-+]?\\s?\\d*)?)\\s?(?:\\x29|$))',
     // pseudo-classes not requiring parameters
     locationpc: '(any\\-link|link|visited|target|defined)\\b',
     useraction: '(hover|active|focus\\-within|focus\\-visible|focus)\\b',
@@ -440,6 +441,41 @@
               p1;
           }
         ) : str;
+    },
+
+  // split ':is(', ':where(', ':matches(', ':not(' and ':has(' into their
+  // selector list argument and the rest of the selector. The argument can
+  // nest parentheses and quote them, which a single regular expression
+  // cannot track, so the closing parenthesis is located by scanning. An
+  // argument left unclosed is closed by EOF, as the CSS Syntax parser does
+  // with any open construct. Returns a match-like array so that callers can
+  // pop() the remainder the same way they do with a RegExp match.
+  matchLogical =
+    function(selector) {
+      var chr, close, escaped, depth = 1, i, l, quote = '',
+      match = selector.match(REX.LogicalPfx);
+
+      if (!match) { return null; }
+
+      for (i = match[0].length, l = selector.length; l > i; ++i) {
+        chr = selector.charAt(i);
+        if (escaped) { escaped = false; continue; }
+        if (chr == '\\') { escaped = true; }
+        else if (quote) { if (chr == quote) { quote = ''; } }
+        else if (chr == '\x22' || chr == '\x27') { quote = chr; }
+        else if (chr == '\x28') { ++depth; }
+        else if (chr == '\x29' && --depth === 0) { break; }
+      }
+
+      // i is the closing parenthesis, or the EOF that stands in for it
+      close = l > i ? i + 1 : i;
+
+      return [
+        selector.slice(0, close),
+        match[1],
+        selector.slice(match[0].length, i).replace(REX.TrimSpaces, ''),
+        selector.slice(close)
+      ];
     },
 
   method = {
@@ -1262,12 +1298,9 @@
             // :is( s1, [ s2, ... ]), :not( s1, [ s2, ... ]),
             // :has( s1, [ s2, ... ]) no nesting is allowed for
             // :where( s1, [ s2, ... ]), :matches( s1, [ s2, ... ]),
-            else if ((match = selector.match(Patterns.logicalsel))) {
+            else if ((match = matchLogical(selector))) {
               match[1] = match[1].toLowerCase();
-              expr = match[2]
-//                .replace(REX.CommaGroup, ',')
-//                .replace(REX.TrimSpaces, '')
-                .replace(/\x22/g, '\\"');
+              expr = match[2].replace(/\x22/g, '\\"');
               switch (match[1]) {
                 case 'is':
                 case 'where':
@@ -1661,7 +1694,7 @@
 
               if (!status) {
                 if (Config.FORGIVING &&
-                  selector.match(/(:(?:is|where)\\x28)/)) {
+                  selector.match(/(:(?:is|where)\x28)/)) {
                   return '';
                 }
                 emit('unknown pseudo-class selector \'' + selector + '\'');
@@ -1689,7 +1722,7 @@
 
         if (!match) {
           if (Config.FORGIVING &&
-            selector.match(/(:(?:is|where)\\x28)/)) {
+            selector.match(/(:(?:is|where)\x28)/)) {
             return '';
           }
           emit('\'' + expression + '\'' + qsInvalid);
@@ -1791,6 +1824,16 @@
             emit('\'' + selectors + '\'' + qsInvalid);
             return Config.VERBOSITY ? undefined : (type ? none : false);
           }
+          // The validator cannot read this selector, but it holds a
+          // forgiving list, which may be where the part it cannot read
+          // lives. Hand on the selector itself rather than the fragments the
+          // validator did match: compiled, the argument of an :is() or
+          // :where() is evaluated inside a try/catch, so the unreadable part
+          // drops out and the rest of the selector still applies. Returning
+          // the fragments compiled each of them as a selector of its own,
+          // which made 'div:not(:is(svg|div))' match every element in the
+          // document rather than the divs.
+          selectors = parsed.match(REX.SplitGroup) || [ parsed ];
         }
       }
 


### PR DESCRIPTION
Two parse defects from the 2.2.25 compiler rework (7a22775): the forgiving-selector fallback tests a doubled escape that can never match, and three pattern groups lost their EOF terminator. Fixing them needs the argument of a logical pseudo-class delimited by a scan rather than a regular expression, since nesting is involved.

<details><summary>Detail, and how it was checked</summary>

Two parse defects from the 2.2.25 compiler rework (7a22775).

The forgiving-selector fallback tests /(:(?:is|where)\\x28)/, where the doubled escape matches a literal backslash rather than an opening parenthesis, so an unsupported argument such as `:not(:is(svg|div))` emits "unknown pseudo-class selector" instead of matching nothing.

The linguistic, logicalsel and treestruct groups lost their `(?:\x29|$)` terminator, so `:not([class]` and `meta[charset="utf-8"` are parse errors rather than being closed by EOF the way the CSS Syntax parser closes any open construct. That is /css/selectors/missing-right-token.html.

Restoring the terminator alone reintroduces the bug it had been papering over: with `[^()]*|.*` the greedy alternative swallows the closing parenthesis of a nested argument, so `:not(:is(div))` compiles `:is(div))`. A regular expression cannot track nesting, so the argument of `:is`, `:where`, `:matches`, `:not` and `:has` is delimited by a scan for the balanced closing parenthesis, honoring quotes and escapes, and falling back to EOF. It returns a match-like array so the compile loop keeps popping the remainder as before.

One more change belongs with these, or the first fix trades a throw for a wrong answer: when the validator cannot read a selector that holds a forgiving list, `parse()` hands on the fragments the validator did match, each compiled as a selector of its own, so `div:not(:is(svg|div))` matches every element in the document rather than the divs. It now hands on the selector, whose forgiving argument is already evaluated inside a try/catch.

Extracted from [#167](https://github.com/dperini/nwsapi/pull/167) as a standalone change: one file, applies to master on its own, and checked against a fixture to confirm it fixes what it describes and moves nothing else.

</details>

<details>
<summary>References: the spec, the browser source, and what each part was reasoned from</summary>

This patch applies to master on its own. The sixteen in this series were checked by cherry-picking them onto master one after another, in this order and in reverse, and all sixteen land without a conflict.

- Spec: [typedef forgiving selector list](https://drafts.csswg.org/selectors-4/#typedef-forgiving-selector-list) — a forgiving selector list drops the items it cannot parse.
- Spec: [consume simple block](https://drafts.csswg.org/css-syntax/#consume-simple-block) — a construct left open at EOF is closed rather than rejected.
- Chromium: [`selector_checker.cc#L2516`](https://github.com/chromium/chromium/blob/155.0.8041.1/third_party/blink/renderer/core/css/selector_checker.cc#L2516) — `:is()` and `:where()` match any item in the list.
- MDN: [`:is`](https://developer.mozilla.org/en-US/docs/Web/CSS/:is).

</details>

