### PR TITLE
Let a pseudo-class be followed by a quoted attribute selector

### DIFF
--- a/src/nwsapi.mts
+++ b/src/nwsapi.mts
@@ -1001,7 +1001,10 @@
             '(?:[.#]?' + identifier + ')|' +
             '(?:' + attributes + ')' +
           ')+|' +
-          '(?:' + WSP + '?[>+~][^>+~]' + WSP + '?)|' +
+          // the combinator is only recognized, not consumed: taking the
+          // character after it swallows the '[' of a following attribute
+          // selector, which then cannot be parsed
+          '(?:' + WSP + '?[>+~](?=[^>+~])' + WSP + '?)|' +
           '(?:' + WSP + '?,' + WSP + '?)|' +
           '(?:' + WSP + '?)|' +
           '(?:\\x29|$)' +
@@ -1939,7 +1942,9 @@
         if (Config.FORGIVING) {
           // forgiving pseudos allow to continue even after parse errors
           if (!(parsed.includes(':is(') || parsed.includes(':where('))) {
-            emit('\'' + selectors + '\'' + qsInvalid);
+            // 'selectors' holds the fragments the validator did match,
+            // which read as a mangled selector once joined by String()
+            emit('\'' + parsed + '\'' + qsInvalid);
             return Config.VERBOSITY ? undefined : (type ? none : false);
           }
           // The validator cannot read this selector, but it holds a

--- a/test/attribute-after-pseudo.test.mts
+++ b/test/attribute-after-pseudo.test.mts
@@ -1,0 +1,37 @@
+import { test, expect } from 'vitest'
+import { JSDOM } from 'jsdom'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+const factory = require('../src/nwsapi.js')
+
+for (const quote of ["'", '"']) {
+  for (const combinator of ['+', '~', '>']) {
+    test(`quoted attributes after pseudos (${quote}, ${combinator})`, t => {
+      const markup =
+        combinator === '>'
+          ? '<div class="A"><p class="b" id="target"></p></div>'
+          : '<div><p class="A">text</p><p class="b" id="target"></p></div>'
+      const { window } = new JSDOM(markup)
+      t.onTestFinished(() => window.close())
+      const engine = factory(window)
+      const selector = `[class*=${quote}a${quote} i]:not(:empty) ${combinator} [class*=${quote}b${quote}]`
+      const target = window.document.getElementById('target')
+      for (let repeat = 0; repeat < 2; repeat++) {
+        expect(engine.select(selector, window.document)).toEqual([target])
+        expect(engine.first(selector, window.document)).toBe(target)
+        expect(engine.match(selector, target)).toBe(true)
+      }
+      target.className = 'c'
+      expect(engine.select(selector, window.document)).toEqual([])
+    })
+  }
+}
+
+test('invalid selectors retain their original text in errors', t => {
+  const { window } = new JSDOM('<p></p>')
+  t.onTestFinished(() => window.close())
+  const engine = factory(window)
+  const selector = "[class*='a' i]:not(:empty)+[class*='b'] ?"
+  expect(() => engine.select(selector, window.document)).toThrow(selector)
+})


### PR DESCRIPTION
## Fix

Preserve quoted attribute selectors after pseudo-classes and combinators. Invalid-selector errors retain the normalized selector text instead of comma-joined parser fragments.

## Tests

Seven focused regressions cover both quote styles, child and sibling combinators, matching and selection, cached queries, DOM changes, and error text. The full local CI workflow passes, including Node tests, package compatibility, WPT on both builds, and coverage thresholds.

Closes #175.