### PR TITLE
Anchor the alternation in the :link and :placeholder-shown tests

### DIFF
--- a/src/nwsapi.js
+++ b/src/nwsapi.js
@@ -132,6 +132,9 @@
     '[\\ufb1d-\\ufdfd]|' +
     '[\\ufe70-\\ufefc])+$'),
 
+  // elements that can carry a hyperlink, see isLink()
+  reLinkName = RegExp('^(?:a|area)$', 'i'),
+
   // emulate firefox error strings
   qsNotArgs = 'Not enough arguments',
   qsInvalid = ' is not a valid selector',
@@ -763,6 +766,12 @@
       return node.hasAttribute('popover') && matchesNative(node, ':popover-open');
     },
 
+  // ':link', ':any-link' and ':visited' share this test
+  isLink =
+    function(node) {
+      return reLinkName.test(node.localName) && node.hasAttribute('href');
+    },
+
   // check media resources is playing
   isPlaying =
     function(media) {
@@ -1345,13 +1354,13 @@
               match[1] = match[1].toLowerCase();
               switch (match[1]) {
                 case 'any-link':
-                  source = 'if((/^a|area$/i.test(e.localName)&&e.hasAttribute("href")||e.visited)){' + source + '}';
+                  source = 'if((s.isLink(e)||e.visited)){' + source + '}';
                   break;
                 case 'link':
-                  source = 'if((/^a|area$/i.test(e.localName)&&e.hasAttribute("href"))){' + source + '}';
+                  source = 'if(s.isLink(e)){' + source + '}';
                   break;
                 case 'visited':
-                  source = 'if((/^a|area$/i.test(e.localName)&&e.hasAttribute("href")&&e.visited)){' + source + '}';
+                  source = 'if((s.isLink(e)&&e.visited)){' + source + '}';
                   break;
                 case 'target':
                   source = 'if(((s.doc.compareDocumentPosition(e)&16)&&s.doc.location.hash&&e.id==s.doc.location.hash.slice(1))){' + source + '}';
@@ -1455,7 +1464,7 @@
                 case 'placeholder-shown':
                   source =
                     'if((' +
-                      '(/^input|textarea$/i.test(e.localName))&&e.hasAttribute("placeholder")&&' +
+                      '(/^(?:input|textarea)$/i.test(e.localName))&&e.hasAttribute("placeholder")&&' +
                       '("|textarea|password|number|search|email|text|tel|url|".includes("|"+e.type+"|"))&&' +
                       '(!s.match(":focus",e))' +
                     ')){' + source + '}';
@@ -2107,6 +2116,7 @@
     isPopoverOpen: isPopoverOpen,
     isFocusable: isFocusable,
     isContentEditable: isContentEditable,
+    isLink: isLink,
     hasAttributeNS: hasAttributeNS
   },
 


### PR DESCRIPTION
`/^a|area$/` alternates `^a` with `area$` rather than anchoring an alternation, so `:link` and `:any-link` match any element whose name begins with `a`, `<abbr href>` among them. `/^input|textarea$/` in `:placeholder-shown` has the same shape.

<details><summary>Detail, and how it was checked</summary>

`/^a|area$/` reads as `^a` or `area$`, so it accepts any element whose name begins with `a`. `:link` and `:any-link` therefore match `<abbr href="...">`, where browsers match only `<a>` and `<area>`. It agrees with browsers on those two, which is why the test suites do not catch it.

`/^input|textarea$/` in `:placeholder-shown` has the same shape; there the surrounding conditions happen to mask it.

The link test is hoisted into a helper at the same time, so the three places that need it share one definition.

Extracted from [#167](https://github.com/dperini/nwsapi/pull/167) as a standalone change: one file, applies to master on its own, and checked against a fixture to confirm it fixes what it describes and moves nothing else.

</details>

<details>
<summary>References: the spec, the browser source, and what each part was reasoned from</summary>

This patch applies to master on its own. The sixteen in this series were checked by cherry-picking them onto master one after another, in this order and in reverse, and all sixteen land without a conflict.

- Spec: [the any link pseudo](https://drafts.csswg.org/selectors-4/#the-any-link-pseudo) — `:any-link` matches an `a` or `area` element with an `href`.
- Spec: [selector placeholder shown](https://html.spec.whatwg.org/#selector-placeholder-shown) — `:placeholder-shown`, for the pattern of the same shape.
- Chromium: [`selector_checker.cc#L2550`](https://github.com/chromium/chromium/blob/155.0.8041.1/third_party/blink/renderer/core/css/selector_checker.cc#L2550) — `:any-link` is one `IsLink()` predicate.
- Chromium: [`selector_checker.cc#L2553`](https://github.com/chromium/chromium/blob/155.0.8041.1/third_party/blink/renderer/core/css/selector_checker.cc#L2553) — `:link` is the same predicate, unvisited.
- MDN: [`:any-link`](https://developer.mozilla.org/en-US/docs/Web/CSS/:any-link).

</details>

