### PR TITLE
Answer an id selector from the id map instead of walking

### DIFF
--- a/src/nwsapi.js
+++ b/src/nwsapi.js
@@ -142,6 +142,7 @@
 
   // placeholder for global regexp
   reOptimizer,
+  reSimpleId,
   reValidator,
 
   // special handling configuration flags
@@ -457,9 +458,11 @@
     },
 
   // find duplicate ids using iterative walk
+  // Walk 'context' in tree order collecting elements carrying 'id'. The
+  // walk can start at 'from', an element already known to be the first match.
   byIdRaw =
-    function(id, context) {
-      var node = context, nodes = [ ], next = node.firstElementChild;
+    function(id, context, from) {
+      var node = context, nodes = [ ], next = from || node.firstElementChild;
       while ((node = next)) {
         node.id == id && (nodes[nodes.length] = node);
         if ((next = node.firstElementChild || node.nextElementSibling)) continue;
@@ -473,7 +476,7 @@
   // context agnostic getElementById
   byId =
     function(id, context) {
-      var e, i, l, nodes, api = method['#'];
+      var e, i, l, nodes, ownerDoc, api = method['#'];
 
       // duplicates id allowed
       if (Config.IDS_DUPES === false) {
@@ -491,6 +494,25 @@
             return nodes && nodes.length ? nodes : [ nodes ];
           } else return none;
         }
+      }
+
+      // Without document.all, every '#id' used to walk the whole subtree,
+      // which measures 2.4ms against 43ns for getElementById on a
+      // 6300-element document. getElementById cannot answer on its own,
+      // because a document may carry the same id more than once and all of
+      // them match, but it does settle two things in constant time: whether
+      // the id exists anywhere, and where the first one is, since it returns
+      // the first in tree order and any duplicate has to follow it.
+      ownerDoc = context.nodeType == 9 ? context : context.ownerDocument;
+
+      if (ownerDoc && ownerDoc.getElementById &&
+        (context.nodeType == 9 || context.isConnected)) {
+        e = ownerDoc.getElementById(id);
+        // nothing in the document carries the id, so nothing under context does
+        if (!e) { return none; }
+        // scoped to an element, the first document-order match may sit
+        // outside it, and a match inside it would then be missed
+        if (context.nodeType == 9) { return byIdRaw(id, context, e); }
       }
 
       return byIdRaw(id, context);
@@ -923,6 +945,9 @@
 
       // global
       reValidator = RegExp(standardValidator, 'g');
+
+      // a lone '#id', the shape querySelector is asked for most often
+      reSimpleId = RegExp('^#(' + identifier + ')$');
 
       Patterns.id = RegExp('^#(' + identifier + ')(.*)');
       Patterns.tagName = RegExp('^(' + identifier + ')(.*)');
@@ -1822,6 +1847,23 @@
   // equivalent of w3c 'querySelector' method
   first =
     function _querySelector(selectors, context, callback) {
+      var element, match;
+
+      // A lone '#id' against a document is the id map's own question, and the
+      // first match in tree order is exactly what getElementById returns.
+      // Going through select() means building the whole candidate list first,
+      // and without document.all that list is built by walking the document:
+      // 2.4ms against 43ns here. Duplicate ids do not change the answer, only
+      // which of them comes first, and they cannot precede this one. Scoped
+      // to an element the first document-order match may sit outside it, so
+      // that case takes the ordinary path.
+      if (selectors && context && context.nodeType == 9 &&
+        context.getElementById && (match = reSimpleId.exec(selectors))) {
+        element = context.getElementById(unescapeIdentifier(match[1]));
+        if (element && typeof callback == 'function') { callback(element); }
+        return element || null;
+      }
+
       return select(selectors, context,
         typeof callback == 'function' ?
         function firstMatch(element) {


### PR DESCRIPTION
`byId()` falls back to walking the subtree when document.all is missing, which is every id lookup under jsdom, and that walk measures milliseconds where getElementById measures nanoseconds. getElementById settles two cases in constant time: whether the id exists at all, and where the first one is, which is all querySelector wants.

<details><summary>Detail, and how it was checked</summary>

`byId()` reaches for document.all and falls back to walking the subtree element by element when it is missing. jsdom does not implement document.all, so every `#id` takes the walk: 2.4ms on a 6300-element document against 43ns for getElementById. jsdom is where most of nwsapi's traffic is, so this is the common case rather than the fallback.

getElementById cannot answer on its own, since a document may carry an id more than once and querySelectorAll matches all of them. It does settle two things in constant time, and each buys back one case:

  - whether the id exists anywhere. If the document has none, no descendant
of any context has one either, so select(`#missing`) returns immediately: 2.19ms to 0.0007ms.
  - where the first one is, in tree order. querySelector wants exactly that,
so a lone `#id` against a document is answered by the id map: first(`#title`) 3.74ms to 0.0007ms.

For `select()` against a hit the walk still runs, because the duplicates have to be found, but it starts at the first match since none can precede it. Element-scoped queries keep the old path, because the first document-order match may sit outside the context and a match inside it would be missed. So does a detached subtree, which the document's id map knows nothing about.

Extracted from [#167](https://github.com/dperini/nwsapi/pull/167) as a standalone change: one file, applies to master on its own, and checked against the benchmark fixture to confirm the results are identical and nothing else moves.

</details>

<details>
<summary>References: the spec, the browser source, and what each part was reasoned from</summary>

This patch applies to master on its own. The sixteen in this series were checked by cherry-picking them onto master one after another, in this order and in reverse, and all sixteen land without a conflict.

- Spec: [dom nonelementparentnode getelementbyid](https://dom.spec.whatwg.org/#dom-nonelementparentnode-getelementbyid) — getElementById returns the first element in tree order.
- Spec: [scope match a selectors string](https://dom.spec.whatwg.org/#scope-match-a-selectors-string) — what a scoped query has to match.
- MDN: [`getElementById`](https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementById).

</details>

