### PR TITLE
Make :enabled the complement of :disabled, fieldsets included

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -11,21 +11,21 @@ Query contexts default to the factory document when omitted. `closest()`, `first
 
 | Method | Result |
 | --- | --- |
-| [`byClass(cls, context)`](../src/nwsapi.mts#L2982) | Returns elements with the class name. |
-| [`byId(id, context)`](../src/nwsapi.mts#L2980) | Returns elements with the ID. Duplicate IDs are allowed by default. |
-| [`byTag(tag, context)`](../src/nwsapi.mts#L2981) | Returns elements with the tag name. Use `*` for all elements. |
-| [`closest(selectors, element, callback)`](../src/nwsapi.mts#L2988) | Returns the nearest match, starting with the element, or `null`. |
-| [`compile(selector, mode, callback)`](../src/nwsapi.mts#L2990) | Compiles a selector into a resolver function. This is an advanced API. |
-| [`configure(option, clear)`](../src/nwsapi.mts#L2991) | Reads or changes options. Pass `true` as the second argument to clear compiled selectors. |
-| [`emit(message, proto)`](../src/nwsapi.mts#L2993) | Reports an error using the configured error policy. |
-| [`first(selectors, context, callback)`](../src/nwsapi.mts#L2984) | Returns the first matching descendant, or `null`. |
-| [`install(all)`](../src/nwsapi.mts#L2999) | Replaces native selector methods. Pass `true` to also replace collection methods. |
-| [`match(selectors, element, callback)`](../src/nwsapi.mts#L2985) | Returns whether the element matches. |
-| [`registerCombinator(combinator, resolver)`](../src/nwsapi.mts#L3006) | Adds a relationship between elements using trusted resolver code. |
-| [`registerOperator(operator, resolver)`](../src/nwsapi.mts#L3031) | Adds an attribute operator using a resolver with `p1`, `p2`, and `p3` fields. |
-| [`registerSelector(name, rexp, func)`](../src/nwsapi.mts#L3053) | Adds a selector pattern and a compiler callback that returns `source` and `status`. |
-| [`select(selectors, context, callback)`](../src/nwsapi.mts#L2986) | Returns an array of matching descendants, or an empty array. |
-| [`uninstall()`](../src/nwsapi.mts#L3000) | Restores the native methods saved by `install()`. |
+| [`byClass(cls, context)`](../src/nwsapi.mts#L3003) | Returns elements with the class name. |
+| [`byId(id, context)`](../src/nwsapi.mts#L3001) | Returns elements with the ID. Duplicate IDs are allowed by default. |
+| [`byTag(tag, context)`](../src/nwsapi.mts#L3002) | Returns elements with the tag name. Use `*` for all elements. |
+| [`closest(selectors, element, callback)`](../src/nwsapi.mts#L3009) | Returns the nearest match, starting with the element, or `null`. |
+| [`compile(selector, mode, callback)`](../src/nwsapi.mts#L3011) | Compiles a selector into a resolver function. This is an advanced API. |
+| [`configure(option, clear)`](../src/nwsapi.mts#L3012) | Reads or changes options. Pass `true` as the second argument to clear compiled selectors. |
+| [`emit(message, proto)`](../src/nwsapi.mts#L3014) | Reports an error using the configured error policy. |
+| [`first(selectors, context, callback)`](../src/nwsapi.mts#L3005) | Returns the first matching descendant, or `null`. |
+| [`install(all)`](../src/nwsapi.mts#L3020) | Replaces native selector methods. Pass `true` to also replace collection methods. |
+| [`match(selectors, element, callback)`](../src/nwsapi.mts#L3006) | Returns whether the element matches. |
+| [`registerCombinator(combinator, resolver)`](../src/nwsapi.mts#L3027) | Adds a relationship between elements using trusted resolver code. |
+| [`registerOperator(operator, resolver)`](../src/nwsapi.mts#L3052) | Adds an attribute operator using a resolver with `p1`, `p2`, and `p3` fields. |
+| [`registerSelector(name, rexp, func)`](../src/nwsapi.mts#L3074) | Adds a selector pattern and a compiler callback that returns `source` and `status`. |
+| [`select(selectors, context, callback)`](../src/nwsapi.mts#L3007) | Returns an array of matching descendants, or an empty array. |
+| [`uninstall()`](../src/nwsapi.mts#L3021) | Restores the native methods saved by `install()`. |
 
 <details>
 <summary>Configuration</summary>
@@ -60,22 +60,22 @@ These exports support extensions and debugging. Prefer query methods and `config
 
 | Member | Purpose |
 | --- | --- |
-| [`CFG`](../src/nwsapi.mts#L2968) | Contains the compiler syntax settings. |
-| [`Config`](../src/nwsapi.mts#L2994) | Contains the active options. Use `configure()` to change them. |
-| [`M_BODY`](../src/nwsapi.mts#L2971) | Contains the matching resolver body template. |
-| [`M_TEST`](../src/nwsapi.mts#L2975) | Contains the matching resolver test template. |
-| [`matchLambdas`](../src/nwsapi.mts#L2960) | Caches compiled matching functions, not DOM results. |
-| [`matchResolvers`](../src/nwsapi.mts#L2963) | Caches matching plans, not DOM results. |
-| [`N_BODY`](../src/nwsapi.mts#L2972) | Exposes the matching resolver body template. |
-| [`N_TEST`](../src/nwsapi.mts#L2976) | Contains the alternate resolver test template. |
-| [`Operators`](../src/nwsapi.mts#L3002) | Contains registered attribute operators. |
-| [`S_BODY`](../src/nwsapi.mts#L2970) | Contains the selection resolver body template. |
-| [`S_TEST`](../src/nwsapi.mts#L2974) | Contains the selection resolver test template. |
-| [`selectLambdas`](../src/nwsapi.mts#L2961) | Caches compiled selection functions, not DOM results. |
-| [`Selectors`](../src/nwsapi.mts#L3003) | Contains registered selector extensions. |
-| [`selectResolvers`](../src/nwsapi.mts#L2964) | Caches selection plans, not DOM results. |
-| [`Snapshot`](../src/nwsapi.mts#L2995) | Contains the document state and helpers used by compiled selectors. |
-| [`Version`](../src/nwsapi.mts#L2997) | Contains the engine version string. |
+| [`CFG`](../src/nwsapi.mts#L2989) | Contains the compiler syntax settings. |
+| [`Config`](../src/nwsapi.mts#L3015) | Contains the active options. Use `configure()` to change them. |
+| [`M_BODY`](../src/nwsapi.mts#L2992) | Contains the matching resolver body template. |
+| [`M_TEST`](../src/nwsapi.mts#L2996) | Contains the matching resolver test template. |
+| [`matchLambdas`](../src/nwsapi.mts#L2981) | Caches compiled matching functions, not DOM results. |
+| [`matchResolvers`](../src/nwsapi.mts#L2984) | Caches matching plans, not DOM results. |
+| [`N_BODY`](../src/nwsapi.mts#L2993) | Exposes the matching resolver body template. |
+| [`N_TEST`](../src/nwsapi.mts#L2997) | Contains the alternate resolver test template. |
+| [`Operators`](../src/nwsapi.mts#L3023) | Contains registered attribute operators. |
+| [`S_BODY`](../src/nwsapi.mts#L2991) | Contains the selection resolver body template. |
+| [`S_TEST`](../src/nwsapi.mts#L2995) | Contains the selection resolver test template. |
+| [`selectLambdas`](../src/nwsapi.mts#L2982) | Caches compiled selection functions, not DOM results. |
+| [`Selectors`](../src/nwsapi.mts#L3024) | Contains registered selector extensions. |
+| [`selectResolvers`](../src/nwsapi.mts#L2985) | Caches selection plans, not DOM results. |
+| [`Snapshot`](../src/nwsapi.mts#L3016) | Contains the document state and helpers used by compiled selectors. |
+| [`Version`](../src/nwsapi.mts#L3018) | Contains the engine version string. |
 
 </details>
 

--- a/src/nwsapi.mts
+++ b/src/nwsapi.mts
@@ -975,6 +975,47 @@
     },
     // return node if node is focusable
     // or false if node isn't focusable
+    // Whether a form control is disabled, which is not only its own
+    // property: a control inside a disabled fieldset is disabled too, unless it
+    // sits in that fieldset's first legend child.
+    // https://html.spec.whatwg.org/#enabling-and-disabling-form-controls:-the-disabled-attribute
+    isDisabled = function (element) {
+      var legend,
+        name = element.localName,
+        node
+
+      if (element.disabled === true) {
+        return true
+      }
+
+      // an optgroup is disabled by its own attribute and nothing else; an
+      // option is also disabled by the optgroup it is a child of
+      if (name == 'optgroup') {
+        return false
+      }
+      if (name == 'option') {
+        node = element.parentElement
+        return !!node && node.localName == 'optgroup' && node.disabled === true
+      }
+
+      // any disabled fieldset above it, unless it sits in that fieldset's
+      // first legend child, which excuses that fieldset and no other
+      node = element.parentElement
+      while (node) {
+        if (node.localName == 'fieldset' && node.disabled === true) {
+          legend = node.firstElementChild
+          while (legend && legend.localName != 'legend') {
+            legend = legend.nextElementSibling
+          }
+          if (!(legend && legend.contains(element))) {
+            return true
+          }
+        }
+        node = node.parentElement
+      }
+
+      return false
+    },
     isFocusable = function (node) {
       var doc = node.ownerDocument
       if (node.contentDocument && node.localName == 'iframe') {
@@ -2035,48 +2076,26 @@
               match[1] = match[1].toLowerCase()
               switch (match[1]) {
                 case 'enabled':
+                  // the complement of ':disabled' over the same elements
                   source =
-                    'if((("form" in e||/^optgroup$/i.test(e.localName))&&"disabled" in e &&e.disabled===false' +
-                    ')){' +
+                    'if((("form" in e||/^optgroup$/i.test(e.localName))&&' +
+                    '"disabled" in e&&!s.isDisabled(e))){' +
                     source +
                     '}'
                   break
                 case 'disabled':
-                  // https://html.spec.whatwg.org/#enabling-and-disabling-form-controls:-the-disabled-attribute
                   source =
-                    'if((("form" in e||/^optgroup$/i.test(e.localName))&&"disabled" in e)){' +
-                    // F is true if any of the fieldset elements in the ancestry chain has the disabled attribute specified
-                    // L is true if the first legend element of the fieldset contains the element
-                    'var x=0,N=[],F=false,L=false;' +
-                    'if(!(/^(optgroup|option)$/i.test(e.localName))){' +
-                    'n=e.parentElement;' +
-                    'while(n){' +
-                    'if(n.localName=="fieldset"){' +
-                    'N[x++]=n;' +
-                    'if(n.disabled===true){' +
-                    'F=true;' +
-                    'break;' +
-                    '}' +
-                    '}' +
-                    'n=n.parentElement;' +
-                    '}' +
-                    'for(var x=0;x<N.length;x++){' +
-                    'if((n=s.first("legend",N[x]))&&n.contains(e)){' +
-                    'L=true;' +
-                    'break;' +
-                    '}' +
-                    '}' +
-                    '}' +
-                    'if(e.disabled===true||(F&&!L)){' +
+                    'if((("form" in e||/^optgroup$/i.test(e.localName))&&' +
+                    '"disabled" in e&&s.isDisabled(e))){' +
                     source +
-                    '}}'
+                    '}'
                   break
                 case 'read-only':
                 case '-moz-read-only':
                   source =
                     'if(' +
-                    '(/^textarea$/i.test(e.localName)&&(e.readOnly||e.disabled))||' +
-                    '(/^input$/i.test(e.localName)&&("|date|datetime-local|email|month|number|password|search|tel|text|time|url|week|".includes("|"+e.type+"|")?(e.readOnly||e.disabled):true))||' +
+                    '(/^textarea$/i.test(e.localName)&&(e.readOnly||s.isDisabled(e)))||' +
+                    '(/^input$/i.test(e.localName)&&("|date|datetime-local|email|month|number|password|search|tel|text|time|url|week|".includes("|"+e.type+"|")?(e.readOnly||s.isDisabled(e)):true))||' +
                     '(!/^(?:input|textarea)$/i.test(e.localName) && !s.isContentEditable(e))' +
                     '){' +
                     source +
@@ -2086,8 +2105,8 @@
                 case '-moz-read-write':
                   source =
                     'if(' +
-                    '(/^textarea$/i.test(e.localName)&&!e.readOnly&&!e.disabled)||' +
-                    '(/^input$/i.test(e.localName)&&"|date|datetime-local|email|month|number|password|search|tel|text|time|url|week|".includes("|"+e.type+"|")&&!e.readOnly&&!e.disabled)||' +
+                    '(/^textarea$/i.test(e.localName)&&!e.readOnly&&!s.isDisabled(e))||' +
+                    '(/^input$/i.test(e.localName)&&"|date|datetime-local|email|month|number|password|search|tel|text|time|url|week|".includes("|"+e.type+"|")&&!e.readOnly&&!s.isDisabled(e))||' +
                     '(!/^(?:input|textarea)$/i.test(e.localName) && s.isContentEditable(e))' +
                     '){' +
                     source +
@@ -2913,6 +2932,7 @@
       nthOfType: typeof nthOfType
       nthElement: typeof nthElement
       matchesNative: typeof matchesNative
+      isDisabled: typeof isDisabled
       isOpen: typeof isOpen
       isClosed: typeof isClosed
       isModal: typeof isModal
@@ -2944,6 +2964,7 @@
       matchesNative: matchesNative,
       isOpen: isOpen,
       isClosed: isClosed,
+      isDisabled: isDisabled,
       isModal: isModal,
       isFullscreen: isFullscreen,
       isPictureInPicture: isPictureInPicture,

--- a/test/disabled-complement.test.mts
+++ b/test/disabled-complement.test.mts
@@ -1,0 +1,59 @@
+import { test, expect } from 'vitest'
+import { JSDOM } from 'jsdom'
+import factory from '../src/nwsapi.js'
+
+test('disabled fieldsets honor only their own first legend', t => {
+  const { window } = new JSDOM(`<fieldset disabled id="outer">
+    <div></div><legend><input id="exempt"></legend>
+    <legend><input id="second"></legend>
+    <fieldset><legend><input id="nested"></legend></fieldset>
+    <input id="plain"><textarea id="text"></textarea>
+  </fieldset><input disabled id="own"><input id="enabled"><div id="neither"></div>`)
+  t.onTestFinished(() => window.close())
+  const engine = factory(window)
+  for (const id of [
+    'exempt',
+    'second',
+    'nested',
+    'plain',
+    'text',
+    'own',
+    'enabled',
+  ]) {
+    const node = window.document.getElementById(id)
+    const disabled = !['exempt', 'enabled'].includes(id)
+    expect(engine.match(':disabled', node), id).toBe(disabled)
+    expect(engine.match(':enabled', node), id).toBe(!disabled)
+    expect(engine.match(':read-only', node), id).toBe(disabled)
+    expect(engine.match(':read-write', node), id).toBe(!disabled)
+  }
+  const neither = window.document.getElementById('neither')
+  expect(engine.match(':disabled', neither)).toBe(false)
+  expect(engine.match(':enabled', neither)).toBe(false)
+  const outer = window.document.querySelector('fieldset')
+  outer.disabled = false
+  expect(
+    engine.select('input:disabled', window.document).map(e => e.id),
+  ).toEqual(['own'])
+  outer.disabled = true
+  expect(
+    engine.match(':enabled', window.document.getElementById('nested')),
+  ).toBe(false)
+})
+
+test('options inherit disabled only from their immediate optgroup', t => {
+  const { window } = new JSDOM(
+    '<fieldset disabled><select disabled><optgroup id="group" disabled><option id="a"></option></optgroup><option id="b"></option><option disabled id="c"></option></select></fieldset>',
+  )
+  t.onTestFinished(() => window.close())
+  const engine = factory(window)
+  for (const id of ['group', 'a', 'b', 'c']) {
+    const node = window.document.getElementById(id)
+    expect(engine.match(':disabled', node), id).toBe(id !== 'b')
+    expect(engine.match(':enabled', node), id).toBe(id === 'b')
+  }
+  window.document.querySelector('optgroup').disabled = false
+  expect(engine.match(':disabled', window.document.getElementById('a'))).toBe(
+    false,
+  )
+})


### PR DESCRIPTION
## Fix

Use one disabled-state predicate for :disabled, :enabled, :read-only, and :read-write. A disabled fieldset exempts only descendants of its first legend. Nested fieldsets cannot erase an outer restriction. Options inherit disabled state from their immediate optgroup, not their select or fieldset.

## Tests

Focused regressions cover first and later legends, nested fieldsets, own disabled state, non-controls, option groups, and DOM changes. The complete local Docker CI workflow passes, including Node tests, package checks, Chromium, WPT on both builds, and unchanged coverage thresholds.