### PR TITLE
Restore querySelectorAll from the method that was saved for it

### DIFF
--- a/.config/runtime.d.ts
+++ b/.config/runtime.d.ts
@@ -7,6 +7,8 @@ interface NwsapiEngine {
   first(selector: string, context?: Node): Element | null
   match(this: void, selector: string, context: Element): boolean
   configure(options: Record<string, unknown>, clear?: boolean): unknown
+  install(all?: boolean): void
+  uninstall(): void
   registerSelector(
     name: string,
     expression: RegExp,

--- a/src/nwsapi.mts
+++ b/src/nwsapi.mts
@@ -2252,7 +2252,7 @@
         Element.prototype.querySelector =
         HTMLElement.prototype.querySelector = _querySelector;
         Element.prototype.querySelectorAll =
-        HTMLElement.prototype.querySelectorAll = _querySelector;
+        HTMLElement.prototype.querySelectorAll = _querySelectorAll;
       }
       if (_querySelectorAllDoc) {
         Document.prototype.querySelector =

--- a/test/uninstall-restore.test.mts
+++ b/test/uninstall-restore.test.mts
@@ -1,0 +1,29 @@
+import { test, expect } from 'vitest'
+import { JSDOM } from 'jsdom'
+import { readFileSync } from 'node:fs'
+
+test('uninstall restores querySelectorAll and its collection contract', t => {
+  /* oxlint-disable typescript/unbound-method -- Compare method identities without calling detached methods. */
+  const { window } = new JSDOM('<main><p></p><p></p></main>', {
+    runScripts: 'outside-only',
+  })
+  t.onTestFinished(() => window.close())
+  window.eval(
+    readFileSync(new URL('../src/nwsapi.js', import.meta.url), 'utf8'),
+  )
+  const engine = window.NW.Dom
+  const main = window.document.querySelector('main')
+  const original = window.Element.prototype.querySelectorAll
+  for (let repeat = 0; repeat < 2; repeat++) {
+    engine.install()
+    expect(main.querySelectorAll('p').length).toBe(2)
+    engine.uninstall()
+    expect(window.Element.prototype.querySelectorAll).toBe(original)
+    expect(window.HTMLElement.prototype.querySelectorAll).toBe(original)
+    const result = main.querySelectorAll('p')
+    expect(result).toBeInstanceOf(window.NodeList)
+    expect(Array.from(result)).toEqual(Array.from(main.children))
+    expect(main.querySelectorAll('.missing').length).toBe(0)
+    expect(main.querySelector('p')).toBe(main.firstElementChild)
+  }
+})


### PR DESCRIPTION
## Fix

Restore Element and HTMLElement querySelectorAll from the saved collection method when uninstalling.

## Tests

The regression runs two install/uninstall cycles. It checks method identity, NodeList results, ordered element identity, empty results, and the separate querySelector contract. The complete local Docker CI workflow passes, including package checks, Node tests, WPT on both builds, and coverage thresholds.