### PR TITLE
Stop :autofill matching every element

### DIFF
--- a/src/nwsapi.mts
+++ b/src/nwsapi.mts
@@ -91,14 +91,12 @@
     locationpc: '(any\\-link|link|visited|target|defined)\\b',
     useraction: '(hover|active|focus\\-within|focus\\-visible|focus)\\b',
     structural: '(scope|root|empty|(?:(?:first|last|only)(?:-child|\\-of\\-type)))\\b',
-    inputstate: '(enabled|disabled|read\\-only|read\\-write|placeholder\\-shown|default)\\b',
+    inputstate: '(enabled|disabled|read\\-only|read\\-write|placeholder\\-shown|default|autofill|-webkit\\-autofill)\\b',
     inputvalue: '(checked|indeterminate|required|optional|valid|invalid|in\\-range|out\\-of\\-range)\\b',
     // pseudo-classes not requiring parameters and describing functional state
     rsrc_state: '(playing|paused|seeking|buffering|stalled|muted|volume\\-locked)\\b',
     disp_state: '(open|closed|modal|fullscreen|picture\\-in\\-picture|popover\\-open|popover)\\b',
     time_state: '(current|past|future)\\b',
-    // pseudo-classes for parsing only selectors
-    pseudo_nop: '(autofill|-webkit\\-autofill)\\b',
     // pseudo-elements starting with single colon (:)
     pseudo_sng: '(after|before|first\\-letter|first\\-line)\\b',
     // pseudo-elements starting with double colon (::)
@@ -118,7 +116,6 @@
     time_state: RegExp('^:(?:' + GROUPS.time_state + ')(.*)', 'i'),
     locationpc: RegExp('^:(?:' + GROUPS.locationpc + ')(.*)', 'i'),
     logicalsel: RegExp('^:(?:' + GROUPS.logicalsel + ')(.*)', 'i'),
-    pseudo_nop: RegExp('^:(?:' + GROUPS.pseudo_nop + ')(.*)', 'i'),
     pseudo_sng: RegExp('^:(?:' + GROUPS.pseudo_sng + ')(.*)', 'i'),
     pseudo_dbl: RegExp('^:(?:' + GROUPS.pseudo_dbl + ')(.*)', 'i'),
     // combinator symbols
@@ -1618,7 +1615,7 @@
                   break;
                 case 'autofill':
                 case '-webkit-autofill':
-                  source = 'if(e.matches&&e.matches(":-webkit-autofill,:autofill")){' + source + '}';
+                  source = 'if(s.matchesNative(e,":autofill")||s.matchesNative(e,":-webkit-autofill")){' + source + '}';
                   break;
                 case 'placeholder-shown':
                   source =
@@ -1775,11 +1772,6 @@
                   emit('\'' + expression + '\'' + qsInvalid);
                   break;
               }
-            }
-
-            // placeholder for parse only no-op selectors
-            else if ((match = selector.match(Patterns.pseudo_nop))) {
-              break;
             }
 
             // allow pseudo-elements starting with single colon (:)
@@ -2336,6 +2328,7 @@
     match: typeof match; matchForgiving: typeof matchForgiving;
     select: typeof select; ancestor: typeof ancestor;
     nthOfType: typeof nthOfType; nthElement: typeof nthElement;
+    matchesNative: typeof matchesNative;
     isOpen: typeof isOpen; isClosed: typeof isClosed; isModal: typeof isModal;
     isFullscreen: typeof isFullscreen; isPictureInPicture: typeof isPictureInPicture;
     isPopoverOpen: typeof isPopoverOpen; isFocusable: typeof isFocusable;
@@ -2360,6 +2353,7 @@
     nthOfType: nthOfType,
     nthElement: nthElement,
 
+    matchesNative: matchesNative,
     isOpen: isOpen,
     isClosed: isClosed,
     isModal: isModal,

--- a/test/autofill.test.mts
+++ b/test/autofill.test.mts
@@ -1,0 +1,52 @@
+import { test, expect } from 'vitest'
+import { JSDOM } from 'jsdom'
+import factory from '../src/nwsapi.js'
+
+for (const pseudo of [':autofill', ':-webkit-autofill']) {
+  test(`${pseudo} does not match ordinary elements or skip its suffix`, t => {
+    const { window } = new JSDOM('<input id="a"><input id="b"><div></div>')
+    t.onTestFinished(() => window.close())
+    const engine = factory(window)
+    expect(engine.select(pseudo, window.document)).toEqual([])
+    expect(engine.select(`input${pseudo}`, window.document)).toEqual([])
+    expect(() => engine.select(`${pseudo}:unknown`, window.document)).toThrow()
+    const input = window.document.getElementById('a')
+    let filled = true
+    Object.defineProperty(input, 'matches', { value: () => filled })
+    for (let repeat = 0; repeat < 2; repeat++) {
+      filled = true
+      expect(engine.select(`input${pseudo}#a`, window.document)).toEqual([
+        input,
+      ])
+      expect(engine.first(`input${pseudo}#a`, window.document)).toBe(input)
+      expect(engine.match(`${pseudo}#b`, input)).toBe(false)
+      filled = false
+      expect(engine.select(`input${pseudo}#a`, window.document)).toEqual([])
+    }
+  })
+}
+
+test('autofill retains alias fallback without recursive host calls', t => {
+  const { window } = new JSDOM('<input>')
+  t.onTestFinished(() => window.close())
+  const engine = factory(window)
+  const input = window.document.querySelector('input')
+  Object.defineProperty(input, 'matches', {
+    configurable: true,
+    value(selector) {
+      if (selector === ':autofill') throw new Error('unsupported')
+      return selector === ':-webkit-autofill'
+    },
+  })
+  expect(engine.match(':autofill', input)).toBe(true)
+  let calls = 0
+  Object.defineProperty(input, 'matches', {
+    value(selector) {
+      if (++calls > 4) throw new Error('unbounded recursion')
+      return engine.match(selector, input)
+    },
+  })
+  expect(engine.match(':autofill', input)).toBe(false)
+  expect(calls).toBeGreaterThan(0)
+  expect(calls).toBeLessThanOrEqual(2)
+})


### PR DESCRIPTION
## Fix

Route :autofill and :-webkit-autofill through the guarded host matcher from merged #178. Ordinary elements no longer match automatically, and the compiler continues validating the rest of the selector. Genuine autofill state stays live; unsupported or delegating hosts fall back safely.

## Tests

Focused regressions cover both aliases, empty results, matching and selection, changing host state, selector suffixes, unsupported native selectors, and bounded recursion. Tests use direct ESM default imports from the generated CommonJS module.

The full local Docker CI workflow passes on current master, including Node, Chromium, both WPT builds, package compatibility, and unchanged coverage thresholds.