### PR TITLE
Establish shared legacy runtime initialization

### DIFF
--- a/docs/legacy-runtime.md
+++ b/docs/legacy-runtime.md
@@ -1,0 +1,35 @@
+# Legacy runtime support
+
+`Config.LEGACY` defaults to `false`. Enable it before querying with
+`NW.Dom.configure({ LEGACY: true })`. The DOM compatibility layer can also
+enable it for documents that need legacy handling.
+
+Runtime helpers select an implementation on first use. Modern mode uses the
+native capability. Legacy mode checks support once, then uses the native
+implementation or a fallback. Each engine instance reuses that selection.
+Later configuration changes leave initialized helpers and existing resources
+unchanged.
+
+Keep DOM checks scoped to their document. A runtime check cached for the
+engine cannot describe differences between documents.
+
+## Adding capabilities
+
+- Put detection in the helper's legacy initialization path.
+- Use native implementations when available, including in legacy mode.
+- Define the fallback behavior and preserve resource lifetimes.
+- Test both modes, missing or incompatible capabilities, and reuse without
+  repeated detection.
+
+`createWeakMap()` is the first helper. Legacy mode checks
+`typeof WeakMap == 'function'` once. It returns a native map when available
+or `undefined` for the consumer to handle. Consumers must bound their
+fallbacks to avoid retaining unused documents.
+
+## Tests
+
+Use Node.js 18 or newer:
+
+```sh
+node --test test/legacy-runtime.test.cjs
+```

--- a/src/nwsapi.js
+++ b/src/nwsapi.js
@@ -148,10 +148,22 @@
   Config = {
     IDS_DUPES: true,
     FORGIVING: true,
+    LEGACY: false,
     NODE_LIST: false,
     LOGERRORS: true,
     USR_EVENT: true,
     VERBOSITY: true
+  },
+
+  // Select the allocator once, when the first cache is requested. Legacy
+  // hosts probe the constructor; modern hosts use it directly. Capture it
+  // so later allocations do not repeat feature detection.
+  createWeakMap = function() {
+    var Constructor = !Config.LEGACY || typeof WeakMap == 'function' ? WeakMap : undefined;
+    createWeakMap = Constructor ?
+      function() { return new Constructor(); } :
+      function() { return undefined; };
+    return createWeakMap();
   },
 
   NAMESPACE,

--- a/test/legacy-runtime.test.cjs
+++ b/test/legacy-runtime.test.cjs
@@ -1,0 +1,59 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { readFileSync } = require('node:fs');
+const { join } = require('node:path');
+const { test } = require('node:test');
+const vm = require('node:vm');
+const source = readFileSync(join(__dirname, '../src/nwsapi.js'), 'utf8');
+// A test-only hook exercises the internal allocator without adding public API.
+assert.equal(source.split('return Dom;').length, 2);
+const instrumented = source.replace('return Dom;',
+  'Dom.testCreateWeakMap = function() { return createWeakMap(); }; return Dom;');
+
+function documentStub() {
+  const document = {
+    nodeType: 9, contentType: 'text/html', compatMode: 'CSS1Compat',
+    addEventListener() {},
+    getElementsByClassName() { return []; },
+    createElement(name) { return { localName: name.toLowerCase() }; }
+  };
+  document.documentElement = {
+    nodeType: 1, localName: 'html', firstElementChild: null,
+    hasAttribute() { return false; },
+    namespaceURI: 'http://www.w3.org/1999/xhtml', ownerDocument: document
+  };
+  return document;
+}
+
+for (const [name, value, legacy, available] of [
+  ['modern', WeakMap, false, true],
+  ['legacy with WeakMap', WeakMap, true, true],
+  ['legacy without WeakMap', undefined, true, false],
+  ['legacy with a non-callable WeakMap', {}, true, false]
+]) {
+  test(`${name} selects the allocator once`, () => {
+    let reads = 0;
+    const context = { module: { exports: {} }, exports: {} };
+    Object.defineProperty(context, 'WeakMap', { get() { reads++; return value; } });
+    vm.runInNewContext(instrumented, context);
+    const document = documentStub();
+    const nw = context.module.exports({ document, DOMException: Error });
+    assert.equal(nw.configure('LEGACY'), false, 'capability does not determine the flag');
+    nw.configure({ LEGACY: legacy });
+    const first = nw.testCreateWeakMap();
+    const initialReads = reads;
+    assert.ok(initialReads > 0);
+    if (available) {
+      const key = {};
+      first.set(key, 42);
+      assert.equal(first.get(key), 42);
+    } else assert.equal(first, undefined);
+    for (let i = 0; i < 50; i++) {
+      const next = nw.testCreateWeakMap();
+      if (available) assert.notEqual(next, first);
+      else assert.equal(next, undefined);
+    }
+    assert.equal(reads, initialReads, 'allocations must reuse the detected constructor');
+  });
+}


### PR DESCRIPTION
Give #178 and #167 shared runtime initialization that we can extend as more capabilities need legacy handling. Modern mode uses native implementations; legacy mode checks support once and reuses the native implementation or fallback.

`createWeakMap()` is the first helper: legacy mode still uses a native map when available and returns `undefined` otherwise.

Validation: `node --test test/legacy-runtime.test.cjs` passes all 4 tests, including reuse without repeated detection. Both dependent revisions are tested and ready to publish after this merges.
