### PR TITLE
Follow native and observable media and timeline states

### DIFF
--- a/.config/state-pseudos.config.mts
+++ b/.config/state-pseudos.config.mts
@@ -1,0 +1,10 @@
+import { defineConfig } from '@playwright/test'
+import { isAgent } from '../scripts/repo/lib/is-agent.mts'
+
+export default defineConfig({
+  testDir: '../test/repo/e2e/upstream',
+  testMatch: 'state-pseudos.spec.mts',
+  reporter: isAgent() ? 'dot' : 'list',
+  workers: 1,
+  use: { browserName: 'chromium' },
+})

--- a/docs/api.md
+++ b/docs/api.md
@@ -11,21 +11,21 @@ Query contexts default to the factory document when omitted. `closest()`, `first
 
 | Method | Result |
 | --- | --- |
-| [`byClass(cls, context)`](../src/nwsapi.mts#L4351) | Returns elements with the class name. |
-| [`byId(id, context)`](../src/nwsapi.mts#L4349) | Returns elements with the ID. Duplicate IDs are allowed by default. |
-| [`byTag(tag, context)`](../src/nwsapi.mts#L4350) | Returns elements with the tag name. Use `*` for all elements. |
-| [`closest(selectors, element, callback)`](../src/nwsapi.mts#L4357) | Returns the nearest match, starting with the element, or `null`. |
-| [`compile(selector, mode, callback, relative)`](../src/nwsapi.mts#L4359) | Compiles a selector into a resolver function. This is an advanced API. |
-| [`configure(option, clear)`](../src/nwsapi.mts#L4360) | Reads or changes options. Pass `true` as the second argument to clear compiled selectors. |
-| [`emit(message, proto)`](../src/nwsapi.mts#L4362) | Reports an error using the configured error policy. |
-| [`first(selectors, context, callback)`](../src/nwsapi.mts#L4353) | Returns the first matching descendant, or `null`. |
-| [`install(all)`](../src/nwsapi.mts#L4368) | Replaces native selector methods. Pass `true` to also replace collection methods. |
-| [`match(selectors, element, callback)`](../src/nwsapi.mts#L4354) | Returns whether the element matches. |
-| [`registerCombinator(combinator, resolver)`](../src/nwsapi.mts#L4375) | Adds a relationship between elements using trusted resolver code. |
-| [`registerOperator(operator, resolver)`](../src/nwsapi.mts#L4400) | Adds an attribute operator using a resolver with `p1`, `p2`, and `p3` fields. |
-| [`registerSelector(name, rexp, func)`](../src/nwsapi.mts#L4422) | Adds a selector pattern and a compiler callback that returns `source` and `status`. |
-| [`select(selectors, context, callback)`](../src/nwsapi.mts#L4355) | Returns an array of matching descendants, or an empty array. |
-| [`uninstall()`](../src/nwsapi.mts#L4369) | Restores the native methods saved by `install()`. |
+| [`byClass(cls, context)`](../src/nwsapi.mts#L4367) | Returns elements with the class name. |
+| [`byId(id, context)`](../src/nwsapi.mts#L4365) | Returns elements with the ID. Duplicate IDs are allowed by default. |
+| [`byTag(tag, context)`](../src/nwsapi.mts#L4366) | Returns elements with the tag name. Use `*` for all elements. |
+| [`closest(selectors, element, callback)`](../src/nwsapi.mts#L4373) | Returns the nearest match, starting with the element, or `null`. |
+| [`compile(selector, mode, callback, relative)`](../src/nwsapi.mts#L4375) | Compiles a selector into a resolver function. This is an advanced API. |
+| [`configure(option, clear)`](../src/nwsapi.mts#L4376) | Reads or changes options. Pass `true` as the second argument to clear compiled selectors. |
+| [`emit(message, proto)`](../src/nwsapi.mts#L4378) | Reports an error using the configured error policy. |
+| [`first(selectors, context, callback)`](../src/nwsapi.mts#L4369) | Returns the first matching descendant, or `null`. |
+| [`install(all)`](../src/nwsapi.mts#L4384) | Replaces native selector methods. Pass `true` to also replace collection methods. |
+| [`match(selectors, element, callback)`](../src/nwsapi.mts#L4370) | Returns whether the element matches. |
+| [`registerCombinator(combinator, resolver)`](../src/nwsapi.mts#L4391) | Adds a relationship between elements using trusted resolver code. |
+| [`registerOperator(operator, resolver)`](../src/nwsapi.mts#L4416) | Adds an attribute operator using a resolver with `p1`, `p2`, and `p3` fields. |
+| [`registerSelector(name, rexp, func)`](../src/nwsapi.mts#L4438) | Adds a selector pattern and a compiler callback that returns `source` and `status`. |
+| [`select(selectors, context, callback)`](../src/nwsapi.mts#L4371) | Returns an array of matching descendants, or an empty array. |
+| [`uninstall()`](../src/nwsapi.mts#L4385) | Restores the native methods saved by `install()`. |
 
 <details>
 <summary>Configuration</summary>
@@ -60,22 +60,22 @@ These exports support extensions and debugging. Prefer query methods and `config
 
 | Member | Purpose |
 | --- | --- |
-| [`CFG`](../src/nwsapi.mts#L4337) | Contains the compiler syntax settings. |
-| [`Config`](../src/nwsapi.mts#L4363) | Contains the active options. Use `configure()` to change them. |
-| [`M_BODY`](../src/nwsapi.mts#L4340) | Contains the matching resolver body template. |
-| [`M_TEST`](../src/nwsapi.mts#L4344) | Contains the matching resolver test template. |
-| [`matchLambdas`](../src/nwsapi.mts#L4329) | Caches compiled matching functions, not DOM results. |
-| [`matchResolvers`](../src/nwsapi.mts#L4332) | Caches matching plans, not DOM results. |
-| [`N_BODY`](../src/nwsapi.mts#L4341) | Exposes the matching resolver body template. |
-| [`N_TEST`](../src/nwsapi.mts#L4345) | Contains the alternate resolver test template. |
-| [`Operators`](../src/nwsapi.mts#L4371) | Contains registered attribute operators. |
-| [`S_BODY`](../src/nwsapi.mts#L4339) | Contains the selection resolver body template. |
-| [`S_TEST`](../src/nwsapi.mts#L4343) | Contains the selection resolver test template. |
-| [`selectLambdas`](../src/nwsapi.mts#L4330) | Caches compiled selection functions, not DOM results. |
-| [`Selectors`](../src/nwsapi.mts#L4372) | Contains registered selector extensions. |
-| [`selectResolvers`](../src/nwsapi.mts#L4333) | Caches selection plans, not DOM results. |
-| [`Snapshot`](../src/nwsapi.mts#L4364) | Contains the document state and helpers used by compiled selectors. |
-| [`Version`](../src/nwsapi.mts#L4366) | Contains the engine version string. |
+| [`CFG`](../src/nwsapi.mts#L4353) | Contains the compiler syntax settings. |
+| [`Config`](../src/nwsapi.mts#L4379) | Contains the active options. Use `configure()` to change them. |
+| [`M_BODY`](../src/nwsapi.mts#L4356) | Contains the matching resolver body template. |
+| [`M_TEST`](../src/nwsapi.mts#L4360) | Contains the matching resolver test template. |
+| [`matchLambdas`](../src/nwsapi.mts#L4345) | Caches compiled matching functions, not DOM results. |
+| [`matchResolvers`](../src/nwsapi.mts#L4348) | Caches matching plans, not DOM results. |
+| [`N_BODY`](../src/nwsapi.mts#L4357) | Exposes the matching resolver body template. |
+| [`N_TEST`](../src/nwsapi.mts#L4361) | Contains the alternate resolver test template. |
+| [`Operators`](../src/nwsapi.mts#L4387) | Contains registered attribute operators. |
+| [`S_BODY`](../src/nwsapi.mts#L4355) | Contains the selection resolver body template. |
+| [`S_TEST`](../src/nwsapi.mts#L4359) | Contains the selection resolver test template. |
+| [`selectLambdas`](../src/nwsapi.mts#L4346) | Caches compiled selection functions, not DOM results. |
+| [`Selectors`](../src/nwsapi.mts#L4388) | Contains registered selector extensions. |
+| [`selectResolvers`](../src/nwsapi.mts#L4349) | Caches selection plans, not DOM results. |
+| [`Snapshot`](../src/nwsapi.mts#L4380) | Contains the document state and helpers used by compiled selectors. |
+| [`Version`](../src/nwsapi.mts#L4382) | Contains the engine version string. |
 
 </details>
 

--- a/docs/media-time-state.md
+++ b/docs/media-time-state.md
@@ -1,0 +1,30 @@
+# Media and timeline states
+
+Resource selectors use the host's native matcher when it exposes the requested
+state. If native matching is unavailable, HTML audio and video elements use
+observable properties for playing, paused, seeking, muted, and buffering.
+Playback at time zero or while awaiting data can still be playing. Muting reads
+the live `muted` property; setting volume to zero does not set that state.
+
+The buffering fallback requires active playback, an active network load, and
+insufficient data for the next frame. A paused element does not buffer. A network
+load alone does not establish a timed stall: `:stalled` and `:volume-locked`
+require native support and otherwise match nothing. No listeners or timers are
+installed to approximate those host-only states.
+
+Time selectors `:current`, `:past`, `:future`, and `:current(...)` delegate to
+the host timeline and match nothing when it is unavailable. Functional
+`:current()` accepts a nonempty list of compound selectors; its arguments are
+validated even with no candidates or no native timeline. Nested invalid
+arguments follow the existing forgiving-list configuration.
+
+These behaviors follow the draft
+[resource-state definitions](https://drafts.csswg.org/selectors/#resource-pseudos)
+and [time-dimensional definitions](https://drafts.csswg.org/selectors-5/#time-pseudos).
+They do not claim to emulate operating-system volume policy or a host timeline.
+
+Run `pnpm test test/repo/unit/media-state.test.mts` for state contracts and
+`pnpm run test:media` for all retained display-state assertions plus real media
+playback, pause, seek, mute, and completion checks in Chromium. The default CI
+browser command includes this suite. The upstream manifest also includes a
+media/time fixture for combined coverage and both generated builds.

--- a/package.json
+++ b/package.json
@@ -130,7 +130,8 @@
     "upstream:verify": "node scripts/repo/run.mts scripts/repo/git-partial-submodule.mts verify",
     "test:attributes": "node scripts/repo/run.mts node_modules/vitest/vitest.mjs run --config .config/vitest.config.mts test/repo/unit/attribute-parse-error.test.mts",
     "test:attributes:browser": "NWSAPI_BROWSER=1 node scripts/repo/run.mts node_modules/vitest/vitest.mjs run --config .config/vitest.config.mts test/repo/e2e/attribute-strings-browser.test.mts",
-    "test:browser": "NWSAPI_BROWSER=1 node scripts/repo/run.mts node_modules/vitest/vitest.mjs run --config .config/vitest.config.mts test/repo/e2e",
+    "test:browser": "NWSAPI_BROWSER=1 node scripts/repo/run.mts node_modules/vitest/vitest.mjs run --config .config/vitest.config.mts test/repo/e2e && pnpm run test:media",
+    "test:media": "node scripts/repo/run.mts scripts/repo/build.mts && node scripts/repo/run.mts node_modules/@playwright/test/cli.js test --config .config/state-pseudos.config.mts",
     "test:optimizer": "node scripts/repo/run.mts node_modules/vitest/vitest.mjs run --config .config/vitest.config.mts test/repo/unit/optimizer-nesting.test.mts"
   }
 }

--- a/src/nwsapi.mts
+++ b/src/nwsapi.mts
@@ -629,7 +629,7 @@
       list[list.length] = text.slice(start).replace(REX.TrimSpaces, '')
       return list
     },
-    matchLogical = function (selector) {
+    matchLogical = function (selector, prefix?) {
       var chr,
         close,
         escaped,
@@ -637,7 +637,7 @@
         i,
         l,
         quote = '',
-        match = selector.match(REX.LogicalPfx)
+        match = selector.match(prefix || REX.LogicalPfx)
 
       if (!match) {
         return null
@@ -1936,27 +1936,37 @@
     isLink = function (node) {
       return reLinkName.test(tagOf(node)) && hasAttrOf(node, 'href')
     },
-    // check media resources is playing
-    isPlaying = function (media) {
-      // for <audio>, <video>, <source> and <track> elements
-      var parent =
-        media instanceof HTMLMediaElement ? null : media.parentElement
-      return (
-        !!(
-          media &&
-          media.currentTime > 0 &&
-          !media.paused &&
-          !media.ended &&
-          media.readyState > 2
-        ) ||
-        !!(
-          parent &&
-          parent.currentTime > 0 &&
-          !parent.paused &&
-          !parent.ended &&
-          parent.readyState > 2
-        )
-      )
+    // Native state covers host-only timing and volume policy. The fallback
+    // reads HTML media state without treating a loading pause as user intent.
+    isMediaState = function (media, state) {
+      var native = matchesNative(media, ':' + state, undefined)
+      if (native !== undefined) {
+        return native
+      }
+      if (
+        media.namespaceURI !== 'http://www.w3.org/1999/xhtml' ||
+        !/^(audio|video)$/i.test(tagOf(media))
+      ) {
+        return false
+      }
+      switch (state) {
+        case 'playing':
+          return media.paused === false && media.ended !== true
+        case 'paused':
+          return media.paused === true || media.ended === true
+        case 'seeking':
+          return media.seeking === true
+        case 'muted':
+          return media.muted === true
+        case 'buffering':
+          return (
+            isMediaState(media, 'playing') &&
+            media.networkState === 2 &&
+            media.readyState < 3
+          )
+        default:
+          return false
+      }
     },
     // configure the engine to use special handling
     configure = function (option, clear) {
@@ -3267,32 +3277,12 @@
             // resources state pseudo-classes (multimedia state)
             // :playing, :paused, :seeking, :buffering, :stalled, :muted, :volume-locked
             else if ((match = selector.match(Patterns.rsrc_state))) {
-              match[1] = match[1].toLowerCase()
-              switch (match[1]) {
-                case 'playing':
-                  source = 'if(s.isPlaying(e)){' + source + '}'
-                  break
-                case 'paused':
-                  source = 'if(!s.isPlaying(e)){' + source + '}'
-                  break
-                case 'seeking':
-                  source = 'if(!s.isPlaying(e)){' + source + '}'
-                  break
-                case 'buffering':
-                  break
-                case 'stalled':
-                  break
-                case 'muted':
-                  source =
-                    'if(e.localName=="audio"&&e.getAttribute("muted")){' +
-                    source +
-                    '}'
-                  break
-                case 'volume-locked':
-                  break
-                default:
-                  break
-              }
+              source =
+                'if(s.isMediaState(e,' +
+                JSON.stringify(match[1].toLowerCase()) +
+                ')){' +
+                source +
+                '}'
             }
 
             // display state pseudo-classes. Helpers use native matching when
@@ -3323,6 +3313,30 @@
                   emit("'" + expression + "'" + qsInvalid)
                   break
               }
+            }
+
+            // Timelines belong to the host; absent native state matches nothing.
+            else if ((match = selector.match(Patterns.time_state))) {
+              expr = ':' + match[1].toLowerCase()
+              if (expr === ':current' && match[2].charAt(0) === '(') {
+                match = matchLogical(selector, /^:(current)\(/i)
+                if (
+                  !match ||
+                  !match[2] ||
+                  !splitList(match[2]).every(isCompound) ||
+                  !validateLogical(match[2], false)
+                ) {
+                  emit("'" + expression + "'" + qsInvalid)
+                  break
+                }
+                expr += '(' + match[2] + ')'
+              }
+              source =
+                'if(s.matchesNative(e,' +
+                JSON.stringify(expr) +
+                ')){' +
+                source +
+                '}'
             }
 
             // allow pseudo-elements starting with single colon (:)
@@ -4260,6 +4274,7 @@
       ancestor: typeof ancestor
       nthOfType: typeof nthOfType
       nthElement: typeof nthElement
+      isMediaState: typeof isMediaState
       matchesNative: typeof matchesNative
       isRequired: typeof isRequired
       isDisabled: typeof isDisabled
@@ -4321,6 +4336,7 @@
       isContentEditable: isContentEditable,
       isLink: isLink,
       hasAttributeNS: hasAttributeNS,
+      isMediaState: isMediaState,
     },
     // public exported methods/objects
     Dom = {

--- a/test/repo/e2e/upstream/fixtures/media-time-state.html
+++ b/test/repo/e2e/upstream/fixtures/media-time-state.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Media and timeline selector states</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+test(() => {
+  const media = document.createElement('video');
+  document.body.appendChild(media);
+  media.matches = () => { throw new DOMException('Unavailable native state', 'SyntaxError'); };
+  Object.defineProperties(media, {
+    paused: { value: false, configurable: true },
+    readyState: { value: 1, configurable: true },
+    networkState: { value: 2 },
+    seeking: { value: true, configurable: true }
+  });
+  const nw = NW.Dom;
+  assert_true(nw.match(':playing', media));
+  assert_true(nw.match(':buffering', media));
+  assert_false(nw.match(':paused', media));
+  assert_false(nw.match(':stalled', media));
+  assert_true(nw.match(':seeking', media));
+  media.muted = true;
+  assert_true(nw.match(':muted', media));
+  media.muted = false;
+  media.volume = 0;
+  assert_false(nw.match(':muted', media));
+  assert_false(nw.match(':volume-locked', media));
+  Object.defineProperty(media, 'paused', { value: true });
+  assert_false(nw.match(':buffering', media));
+  assert_true(nw.match(':paused', media));
+  assert_false(nw.match(':paused', document.body));
+  media.remove();
+}, 'Unsupported hosts use reflected media state without inventing stall timing');
+test(() => {
+  const node = document.createElement('p');
+  document.body.appendChild(node);
+  for (const selector of [':current', ':past', ':future', ':current(p, .caption)']) {
+    assert_false(NW.Dom.match(selector, node));
+    node.matches = candidate => candidate === selector;
+    assert_true(NW.Dom.match(selector, node));
+    delete node.matches;
+  }
+  node.remove();
+}, 'Timeline selectors consult the host and remain empty without host state');
+</script>

--- a/test/repo/e2e/upstream/fixtures/state-pseudos.html
+++ b/test/repo/e2e/upstream/fixtures/state-pseudos.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>nwsapi state pseudo-class fixture</title>
+</head>
+<body>
+<!--
+  Fixture for test/repo/e2e/upstream/state-pseudos.spec.mts. Element ids are asserted
+  verbatim by the spec — keep them stable.
+-->
+<details id="d-open" open><summary>open details</summary>shown</details>
+<details id="d-closed"><summary>closed details</summary>hidden</details>
+<dialog id="g-open" open>open dialog</dialog>
+<dialog id="g-closed">closed dialog</dialog>
+<video id="vid"></video>
+<div id="plain">plain div</div>
+</body>
+</html>

--- a/test/repo/e2e/upstream/manifest.mts
+++ b/test/repo/e2e/upstream/manifest.mts
@@ -37,6 +37,11 @@ export const manifest: Array<{
   legacyMap?: boolean
 }> = [
   {
+    path: '/_repo/test/repo/e2e/upstream/fixtures/media-time-state.html',
+    note: 'local WPT regression: native and reflected media states and host timelines',
+    install: false,
+  },
+  {
     path: '/_repo/test/repo/e2e/upstream/fixtures/descendant-routing.html',
     note: 'local WPT regression: descendant routes, external ancestors, wide levels, and live mutations',
     install: false,

--- a/test/repo/e2e/upstream/state-pseudos.spec.mts
+++ b/test/repo/e2e/upstream/state-pseudos.spec.mts
@@ -1,0 +1,322 @@
+/*
+ * Committed coverage for the Selectors 4 state pseudo-classes wired into
+ * src/nwsapi.js (:open, :closed, :modal, :fullscreen, :picture-in-picture
+ * and the time-dimensional :current/:past/:future).
+ *
+ * Uses the same init-script mechanism as wpt.spec.mts: src/nwsapi.js is
+ * evaluated and NW.Dom.install() called before any page script runs, then
+ * assertions run in-page against NW.Dom on the fixture page
+ * test/repo/e2e/upstream/fixtures/state-pseudos.html via a local file URL.
+ *
+ * The last test opens the fixture WITHOUT the init script to capture native
+ * Chromium ground truth: NW.Dom.install() patches Document.prototype, so in
+ * an instrumented page even a DOMParser-created XMLDocument goes through the
+ * NW override — the only way to see the native engine is a clean page.
+ */
+/* global window, document, DOMParser */
+// ^ the page.evaluate() callbacks below run inside Chromium, not in Node.
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { expect, test } from '@playwright/test'
+import { REPO_ROOT as repoRoot } from '../../../../scripts/repo/lib/paths.mts'
+
+const nwsapiSource = readFileSync(
+  path.join(repoRoot, 'src', 'nwsapi.js'),
+  'utf8',
+)
+
+const FIXTURE = new URL('./fixtures/state-pseudos.html', import.meta.url).href
+const XML_SOURCE = '<root><details open="open"/><dialog open=""/></root>'
+
+const initScript = `${nwsapiSource}
+;(function () {
+  try {
+    window.NW.Dom.install();
+  } catch (e) {
+    window.__nwInstallError = String((e && e.stack) || e);
+  }
+})();
+`
+
+async function openFixtureWithNW(page) {
+  await page.addInitScript({ content: initScript })
+  const response = await page.goto(FIXTURE)
+  expect(response, `no HTTP response for ${FIXTURE}`).not.toBeNull()
+  expect(
+    response.ok(),
+    `HTTP ${response.status()} for ${FIXTURE} — is scripts/serve.mts the server on port 8000?`,
+  ).toBe(true)
+  expect(
+    await page.evaluate('window.__nwInstallError || null'),
+    'NW.Dom.install() must not throw',
+  ).toBeNull()
+  // NW-install canary (same as wpt.spec.mts): nwsapi returns Arrays.
+  expect(
+    await page.evaluate('Array.isArray(document.querySelectorAll("html"))'),
+    'document.querySelectorAll must return an Array (nwsapi installed)',
+  ).toBe(true)
+}
+
+test.describe('state pseudo-classes (nwsapi installed)', () => {
+  test(':open matches open <details>/<dialog> only', async ({ page }) => {
+    await openFixtureWithNW(page)
+    const result = await page.evaluate(() => {
+      const ids = els => els.map(e => e.id)
+      return {
+        open: ids(window.NW.Dom.select(':open')),
+        detailsOpen: ids(window.NW.Dom.select('details:open')),
+        matchClosedDetails: window.NW.Dom.match(
+          ':open',
+          document.getElementById('d-closed'),
+        ),
+      }
+    })
+    expect(result.open).toEqual(['d-open', 'g-open'])
+    expect(result.detailsOpen).toEqual(['d-open'])
+    expect(result.matchClosedDetails).toBe(false)
+  })
+
+  test(':closed matches <details>/<dialog> without the open property', async ({
+    page,
+  }) => {
+    await openFixtureWithNW(page)
+    const result = await page.evaluate(() => {
+      const ids = els => els.map(e => e.id)
+      return {
+        closed: ids(window.NW.Dom.select(':closed')),
+        detailsClosed: ids(window.NW.Dom.select('details:closed')),
+        matchOpenDetails: window.NW.Dom.match(
+          ':closed',
+          document.getElementById('d-open'),
+        ),
+        // :closed only applies to elements that have an open/closed state, so
+        // a plain <div> is neither :open nor :closed.
+        matchPlainDiv: window.NW.Dom.match(
+          ':closed',
+          document.getElementById('plain'),
+        ),
+      }
+    })
+    expect(result.closed).toEqual(['d-closed', 'g-closed'])
+    expect(result.detailsClosed).toEqual(['d-closed'])
+    expect(result.matchOpenDetails).toBe(false)
+    expect(result.matchPlainDiv).toBe(false)
+  })
+
+  test(':current/:past/:future are valid but never match', async ({ page }) => {
+    await openFixtureWithNW(page)
+    const result = await page.evaluate(() => {
+      const out = {}
+      for (const selector of [':current', ':past', ':future', 'div:future']) {
+        try {
+          out[selector] = window.NW.Dom.select(selector).map(e => e.id)
+        } catch (e) {
+          out[selector] = `threw: ${String(e)}`
+        }
+      }
+      return out
+    })
+    expect(result[':current']).toEqual([])
+    expect(result[':past']).toEqual([])
+    expect(result[':future']).toEqual([])
+    expect(result['div:future']).toEqual([])
+  })
+
+  test(':fullscreen/:modal/:picture-in-picture follow document element pointers', async ({
+    page,
+  }) => {
+    await openFixtureWithNW(page)
+    const result = await page.evaluate(() => {
+      const ids = els => els.map(e => e.id)
+      const out: Record<string, string[]> = {
+        fullscreenStatic: ids(window.NW.Dom.select(':fullscreen')),
+        modalStatic: ids(window.NW.Dom.select(':modal')),
+        pipStatic: ids(window.NW.Dom.select(':picture-in-picture')),
+      }
+      Object.defineProperty(document, 'fullscreenElement', {
+        value: document.getElementById('g-open'),
+        configurable: true,
+      })
+      out.fullscreenAfter = ids(window.NW.Dom.select(':fullscreen'))
+      out.modalAfter = ids(window.NW.Dom.select(':modal'))
+      Object.defineProperty(document, 'pictureInPictureElement', {
+        value: document.getElementById('vid'),
+        configurable: true,
+      })
+      out.pipAfter = ids(window.NW.Dom.select(':picture-in-picture'))
+      return out
+    })
+    // Nothing is really fullscreen/PiP in a static fixture.
+    expect(result.fullscreenStatic).toEqual([])
+    expect(result.modalStatic).toEqual([])
+    expect(result.pipStatic).toEqual([])
+    // With document.fullscreenElement stubbed, both :fullscreen and :modal
+    // (whose detectable half is the fullscreen flag) match exactly that node.
+    expect(result.fullscreenAfter).toEqual(['g-open'])
+    expect(result.modalAfter).toEqual(['g-open'])
+    expect(result.pipAfter).toEqual(['vid'])
+  })
+
+  test(':open never matches in an XML document', async ({ page }) => {
+    await openFixtureWithNW(page)
+    const result = await page.evaluate(xmlSource => {
+      const xdoc = new DOMParser().parseFromString(xmlSource, 'application/xml')
+      const qsaResult = xdoc.querySelectorAll(':open')
+      return {
+        parserError: xdoc.getElementsByTagName('parsererror').length > 0,
+        nwSelect: window.NW.Dom.select(':open', xdoc).length,
+        // install() patches Document.prototype, so this goes through NW too
+        // (native ground truth lives in the uninstrumented test below).
+        qsaLength: qsaResult.length,
+        qsaWentThroughNW: Array.isArray(qsaResult),
+      }
+    }, XML_SOURCE)
+    expect(result.parserError).toBe(false)
+    expect(
+      result.nwSelect,
+      'NW.Dom.select(":open", xmlDoc) must match nothing',
+    ).toBe(0)
+    expect(
+      result.qsaLength,
+      'xdoc.querySelectorAll(":open") must match nothing',
+    ).toBe(0)
+    expect(
+      result.qsaWentThroughNW,
+      'NW override reaches XMLDocument via Document.prototype',
+    ).toBe(true)
+  })
+})
+
+test('native Chromium parity (no nwsapi): :open in HTML and XML', async ({
+  page,
+}) => {
+  // No init script here: this page runs the native engine as ground truth.
+  const response = await page.goto(FIXTURE)
+  expect(response, `no HTTP response for ${FIXTURE}`).not.toBeNull()
+  expect(response.ok(), `HTTP ${response.status()} for ${FIXTURE}`).toBe(true)
+  const result = await page.evaluate(xmlSource => {
+    const xdoc = new DOMParser().parseFromString(xmlSource, 'application/xml')
+    return {
+      qsaIsNative: !Array.isArray(document.querySelectorAll('html')),
+      htmlOpen: Array.from(document.querySelectorAll(':open'), e => e.id),
+      xmlOpen: xdoc.querySelectorAll(':open').length,
+    }
+  }, XML_SOURCE)
+  expect(result.qsaIsNative, 'this page must run the native engine').toBe(true)
+  expect(
+    result.htmlOpen,
+    'native :open agrees with nwsapi on the HTML fixture',
+  ).toEqual(['d-open', 'g-open'])
+  expect(
+    result.xmlOpen,
+    'native :open matches nothing in an XML document',
+  ).toBe(0)
+})
+
+test('real media playback, seeking, muting and completion remain live after install', async ({
+  page,
+}) => {
+  await page.goto(FIXTURE)
+  await page.addScriptTag({ content: nwsapiSource })
+  const result = await page.evaluate(async () => {
+    // oxlint-disable-next-line typescript/unbound-method -- Called with the media receiver.
+    const native = Element.prototype.matches
+    const nw = window.NW.Dom
+    nw.install()
+    const audio = document.createElement('audio')
+    document.body.appendChild(audio)
+    const samples = 8000
+    const bytes = new Uint8Array(44 + samples * 2)
+    const view = new DataView(bytes.buffer)
+    function text(offset, value) {
+      for (let i = 0; i < value.length; i++) {
+        bytes[offset + i] = value.charCodeAt(i)
+      }
+    }
+    text(0, 'RIFF')
+    text(8, 'WAVE')
+    text(12, 'fmt ')
+    text(36, 'data')
+    view.setUint32(4, bytes.length - 8, true)
+    view.setUint32(16, 16, true)
+    view.setUint16(20, 1, true)
+    view.setUint16(22, 1, true)
+    view.setUint32(24, samples, true)
+    view.setUint32(28, samples * 2, true)
+    view.setUint16(32, 2, true)
+    view.setUint16(34, 16, true)
+    view.setUint32(40, samples * 2, true)
+    const url = URL.createObjectURL(new Blob([bytes], { type: 'audio/wav' }))
+    const event = name =>
+      new Promise(resolve =>
+        audio.addEventListener(name, resolve, { once: true }),
+      )
+    const parity = []
+    function state(selector) {
+      const actual = nw.match(selector, audio)
+      try {
+        parity.push([actual, native.call(audio, selector)])
+      } catch {
+        /* Native syntax can be unavailable. */
+      }
+      return actual
+    }
+    try {
+      const ready = event('canplay')
+      audio.src = url
+      audio.muted = true
+      await ready
+      const initialPaused = state(':paused')
+      await audio.play()
+      const playing = state(':playing')
+      const playingPaused = state(':paused')
+      audio.pause()
+      const paused = state(':paused')
+      const sought = event('seeked')
+      audio.currentTime = 0.5
+      const seeking = state(':seeking')
+      await sought
+      const soughtState = state(':seeking')
+      const muted = state(':muted')
+      audio.muted = false
+      audio.volume = 0
+      const volumeZeroMuted = state(':muted')
+      const ended = event('ended')
+      await audio.play()
+      await ended
+      return {
+        initialPaused,
+        playing,
+        playingPaused,
+        paused,
+        seeking,
+        soughtState,
+        muted,
+        volumeZeroMuted,
+        endedPaused: state(':paused'),
+        endedPlaying: state(':playing'),
+        parity,
+      }
+    } finally {
+      audio.pause()
+      audio.remove()
+      URL.revokeObjectURL(url)
+    }
+  })
+  const { parity, ...states } = result
+  expect(states).toEqual({
+    initialPaused: true,
+    playing: true,
+    playingPaused: false,
+    paused: true,
+    seeking: true,
+    soughtState: false,
+    muted: true,
+    volumeZeroMuted: false,
+    endedPaused: true,
+    endedPlaying: false,
+  })
+  for (const [actual, expected] of parity) {
+    expect(actual).toBe(expected)
+  }
+})

--- a/test/repo/unit/media-state.test.mts
+++ b/test/repo/unit/media-state.test.mts
@@ -1,0 +1,199 @@
+import assert from 'node:assert/strict'
+import { test } from 'vitest'
+import { JSDOM } from 'jsdom'
+import factory from '../../../src/nwsapi.js'
+
+function setMatcher(element: Element, matcher: (selector: string) => boolean) {
+  Reflect.set(element, 'matches', matcher)
+}
+
+for (const state of ['buffering', 'stalled']) {
+  test(':' + state + ' implies :playing', t => {
+    const { window } = new JSDOM('<video id="v"></video>')
+    t.onTestFinished(() => window.close())
+    const video = window.document.getElementById('v')
+    setMatcher(video, () => {
+      throw new window.DOMException('Unavailable native state', 'SyntaxError')
+    })
+    const nw = factory(window)
+    Object.defineProperties(video, {
+      networkState: { value: 2 },
+      currentTime: { value: 1 },
+      paused: { value: false },
+      readyState: { value: 1 },
+    })
+    if (state === 'stalled') {
+      setMatcher(video, selector => {
+        if (selector === ':stalled' || selector === ':playing') {
+          return true
+        }
+        if (selector === ':paused') {
+          return false
+        }
+        throw new window.DOMException('Unsupported selector', 'SyntaxError')
+      })
+    }
+    assert.equal(nw.match(':' + state, video), true)
+    assert.equal(nw.match(':playing', video), true)
+    assert.equal(nw.match(':paused', video), false)
+  })
+}
+
+test('non-media elements do not acquire paused or seeking state', t => {
+  const { window } = new JSDOM('<div id="d"></div>')
+  t.onTestFinished(() => window.close())
+  const nw = factory(window)
+  for (const selector of [
+    ':paused',
+    ':seeking',
+    ':buffering',
+    ':stalled',
+    ':volume-locked',
+  ]) {
+    assert.equal(nw.match(selector, window.document.getElementById('d')), false)
+  }
+})
+
+test('playback fallback includes startup and buffering, and distinguishes seeking', t => {
+  const { window } = new JSDOM(
+    '<audio></audio><video><source><track></video><div></div>',
+  )
+  t.onTestFinished(() => window.close())
+  const host = {
+    document: window.document,
+    DOMException: window.DOMException,
+  }
+  const nw = factory(host)
+  nw.configure({ LEGACY: true })
+  for (const media of window.document.querySelectorAll<HTMLMediaElement>(
+    'audio,video',
+  )) {
+    setMatcher(media, () => {
+      throw new window.DOMException('Unavailable native state', 'SyntaxError')
+    })
+    Object.defineProperties(media, {
+      paused: { value: false, configurable: true },
+      currentTime: { value: 0 },
+      readyState: { value: 1, configurable: true },
+      networkState: { value: 2 },
+      seeking: { value: false, configurable: true },
+    })
+    assert.equal(nw.match(':playing', media), true)
+    assert.equal(nw.match(':paused', media), false)
+    assert.equal(nw.match(':buffering', media), true)
+    assert.equal(nw.match(':stalled', media), false)
+    assert.equal(nw.match(':seeking', media), false)
+    Object.defineProperty(media, 'seeking', { value: true })
+    assert.equal(nw.match(':seeking', media), true)
+    Object.defineProperty(media, 'readyState', { value: 4 })
+    assert.equal(nw.match(':buffering', media), false)
+    Object.defineProperty(media, 'paused', { value: true })
+    assert.equal(nw.match(':playing', media), false)
+    assert.equal(nw.match(':paused', media), true)
+  }
+  for (const element of window.document.querySelectorAll('source,track,div')) {
+    for (const state of [
+      'playing',
+      'paused',
+      'seeking',
+      'buffering',
+      'stalled',
+      'muted',
+      'volume-locked',
+    ]) {
+      assert.equal(nw.match(':' + state, element), false)
+    }
+  }
+})
+
+test('muting follows the live audio and video property, not volume or the attribute', t => {
+  const { window } = new JSDOM('<audio muted></audio><video muted></video>')
+  t.onTestFinished(() => window.close())
+  const nw = factory(window)
+  for (const media of window.document.querySelectorAll<HTMLMediaElement>(
+    'audio,video',
+  )) {
+    setMatcher(media, () => {
+      throw new window.DOMException('Unavailable native state', 'SyntaxError')
+    })
+    media.muted = true
+    assert.equal(nw.match(':muted', media), true)
+    media.muted = false
+    media.volume = 0
+    assert.equal(nw.match(':muted', media), false)
+    assert.equal(nw.match(':volume-locked', media), false)
+  }
+})
+
+test('native state wins, including host-only stalls, volume locks and timelines', t => {
+  const { window } = new JSDOM('<video></video><p></p>')
+  t.onTestFinished(() => window.close())
+  const nw = factory(window)
+  const media = window.document.querySelector('video')
+  let active = true
+  setMatcher(media, () => active)
+  for (const state of [
+    'playing',
+    'paused',
+    'seeking',
+    'buffering',
+    'stalled',
+    'muted',
+    'volume-locked',
+  ]) {
+    assert.equal(nw.match(':' + state, media), true)
+  }
+  active = false
+  assert.equal(nw.match(':paused', media), false)
+  const paragraph = window.document.querySelector('p')
+  for (const selector of [
+    ':current',
+    ':past',
+    ':future',
+    ':current(p, .caption)',
+  ]) {
+    setMatcher(paragraph, candidate => candidate === selector)
+    assert.equal(nw.match(selector, paragraph), true)
+    setMatcher(paragraph, () => false)
+    assert.equal(nw.match(selector, paragraph), false)
+  }
+})
+
+test('time selectors remain valid without a timeline and validate current arguments', t => {
+  const { window } = new JSDOM('<p></p>')
+  t.onTestFinished(() => window.close())
+  const nw = factory(window)
+  for (const selector of [
+    ':current',
+    ':past',
+    ':future',
+    ':current(p, .caption)',
+  ]) {
+    assert.deepEqual(nw.select(selector), [])
+  }
+  for (const selector of [
+    ':current()',
+    ':current(',
+    ':current(")',
+    ':current(/*)',
+    ':current(p > span)',
+    ':current(p,)',
+    ':current(:unknown)',
+  ]) {
+    assert.throws(() => nw.select(selector), { name: 'SyntaxError' })
+    assert.throws(
+      () => nw.select(selector, window.document.createDocumentFragment()),
+      { name: 'SyntaxError' },
+    )
+  }
+  nw.configure({ FORGIVING: true })
+  assert.deepEqual(nw.select(':is(:current(), p)'), [
+    window.document.querySelector('p'),
+  ])
+  assert.deepEqual(nw.select(':is(:current(:unknown), p)'), [
+    window.document.querySelector('p'),
+  ])
+  assert.deepEqual(nw.select(':where(:current(p > span), p)'), [
+    window.document.querySelector('p'),
+  ])
+})


### PR DESCRIPTION
Media selectors now use native host state when available and fall back to observable HTML audio/video properties. This fixes ordinary elements matching paused/seeking states, playback at time zero or during buffering, and muting that depended on the audio content attribute. Buffering can match while playback remains active. Timed stalls and volume locks require native support; the engine does not infer them from a network flag.

Time selectors delegate to the host timeline and match nothing when it is unavailable. Functional `:current()` validates a nonempty compound-selector list, including with no candidates, and follows existing forgiving-list behavior.

The changes follow the draft [resource-state definitions](https://drafts.csswg.org/selectors/#resource-pseudos) and [time-dimensional definitions](https://drafts.csswg.org/selectors-5/#time-pseudos). The retained browser assertions now live under `test/repo/e2e` and run through the default CI browser command. New tests cover real playback, pause, seeking, muting, completion, native delegation, unsupported-host fallbacks, and malformed time selectors. The two archived expected failures are passing contracts; host-only limitations are documented in `docs/media-time-state.md`.

Rebased as one commit onto the completed selector and benchmark changes. Validation: 585 Node tests, 22 packed-package tests, 20 existing browser tests, 7 media/display browser tests, and 58 WPT pages pass. Types, lint, formatting, repository checks, and coverage thresholds pass. Combined coverage: 86.42% statements, 77.72% branches, 85.16% functions, 85.31% lines.
