### PR TITLE
Preserve lazy hover state across document switches

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -11,21 +11,21 @@ Query contexts default to the factory document when omitted. `closest()`, `first
 
 | Method | Result |
 | --- | --- |
-| [`byClass(cls, context)`](../src/nwsapi.mts#L4166) | Returns elements with the class name. |
-| [`byId(id, context)`](../src/nwsapi.mts#L4164) | Returns elements with the ID. Duplicate IDs are allowed by default. |
-| [`byTag(tag, context)`](../src/nwsapi.mts#L4165) | Returns elements with the tag name. Use `*` for all elements. |
-| [`closest(selectors, element, callback)`](../src/nwsapi.mts#L4172) | Returns the nearest match, starting with the element, or `null`. |
-| [`compile(selector, mode, callback, relative)`](../src/nwsapi.mts#L4174) | Compiles a selector into a resolver function. This is an advanced API. |
-| [`configure(option, clear)`](../src/nwsapi.mts#L4175) | Reads or changes options. Pass `true` as the second argument to clear compiled selectors. |
-| [`emit(message, proto)`](../src/nwsapi.mts#L4177) | Reports an error using the configured error policy. |
-| [`first(selectors, context, callback)`](../src/nwsapi.mts#L4168) | Returns the first matching descendant, or `null`. |
-| [`install(all)`](../src/nwsapi.mts#L4183) | Replaces native selector methods. Pass `true` to also replace collection methods. |
-| [`match(selectors, element, callback)`](../src/nwsapi.mts#L4169) | Returns whether the element matches. |
-| [`registerCombinator(combinator, resolver)`](../src/nwsapi.mts#L4190) | Adds a relationship between elements using trusted resolver code. |
-| [`registerOperator(operator, resolver)`](../src/nwsapi.mts#L4215) | Adds an attribute operator using a resolver with `p1`, `p2`, and `p3` fields. |
-| [`registerSelector(name, rexp, func)`](../src/nwsapi.mts#L4237) | Adds a selector pattern and a compiler callback that returns `source` and `status`. |
-| [`select(selectors, context, callback)`](../src/nwsapi.mts#L4170) | Returns an array of matching descendants, or an empty array. |
-| [`uninstall()`](../src/nwsapi.mts#L4184) | Restores the native methods saved by `install()`. |
+| [`byClass(cls, context)`](../src/nwsapi.mts#L4194) | Returns elements with the class name. |
+| [`byId(id, context)`](../src/nwsapi.mts#L4192) | Returns elements with the ID. Duplicate IDs are allowed by default. |
+| [`byTag(tag, context)`](../src/nwsapi.mts#L4193) | Returns elements with the tag name. Use `*` for all elements. |
+| [`closest(selectors, element, callback)`](../src/nwsapi.mts#L4200) | Returns the nearest match, starting with the element, or `null`. |
+| [`compile(selector, mode, callback, relative)`](../src/nwsapi.mts#L4202) | Compiles a selector into a resolver function. This is an advanced API. |
+| [`configure(option, clear)`](../src/nwsapi.mts#L4203) | Reads or changes options. Pass `true` as the second argument to clear compiled selectors. |
+| [`emit(message, proto)`](../src/nwsapi.mts#L4205) | Reports an error using the configured error policy. |
+| [`first(selectors, context, callback)`](../src/nwsapi.mts#L4196) | Returns the first matching descendant, or `null`. |
+| [`install(all)`](../src/nwsapi.mts#L4211) | Replaces native selector methods. Pass `true` to also replace collection methods. |
+| [`match(selectors, element, callback)`](../src/nwsapi.mts#L4197) | Returns whether the element matches. |
+| [`registerCombinator(combinator, resolver)`](../src/nwsapi.mts#L4218) | Adds a relationship between elements using trusted resolver code. |
+| [`registerOperator(operator, resolver)`](../src/nwsapi.mts#L4243) | Adds an attribute operator using a resolver with `p1`, `p2`, and `p3` fields. |
+| [`registerSelector(name, rexp, func)`](../src/nwsapi.mts#L4265) | Adds a selector pattern and a compiler callback that returns `source` and `status`. |
+| [`select(selectors, context, callback)`](../src/nwsapi.mts#L4198) | Returns an array of matching descendants, or an empty array. |
+| [`uninstall()`](../src/nwsapi.mts#L4212) | Restores the native methods saved by `install()`. |
 
 <details>
 <summary>Configuration</summary>
@@ -60,22 +60,22 @@ These exports support extensions and debugging. Prefer query methods and `config
 
 | Member | Purpose |
 | --- | --- |
-| [`CFG`](../src/nwsapi.mts#L4152) | Contains the compiler syntax settings. |
-| [`Config`](../src/nwsapi.mts#L4178) | Contains the active options. Use `configure()` to change them. |
-| [`M_BODY`](../src/nwsapi.mts#L4155) | Contains the matching resolver body template. |
-| [`M_TEST`](../src/nwsapi.mts#L4159) | Contains the matching resolver test template. |
-| [`matchLambdas`](../src/nwsapi.mts#L4144) | Caches compiled matching functions, not DOM results. |
-| [`matchResolvers`](../src/nwsapi.mts#L4147) | Caches matching plans, not DOM results. |
-| [`N_BODY`](../src/nwsapi.mts#L4156) | Exposes the matching resolver body template. |
-| [`N_TEST`](../src/nwsapi.mts#L4160) | Contains the alternate resolver test template. |
-| [`Operators`](../src/nwsapi.mts#L4186) | Contains registered attribute operators. |
-| [`S_BODY`](../src/nwsapi.mts#L4154) | Contains the selection resolver body template. |
-| [`S_TEST`](../src/nwsapi.mts#L4158) | Contains the selection resolver test template. |
-| [`selectLambdas`](../src/nwsapi.mts#L4145) | Caches compiled selection functions, not DOM results. |
-| [`Selectors`](../src/nwsapi.mts#L4187) | Contains registered selector extensions. |
-| [`selectResolvers`](../src/nwsapi.mts#L4148) | Caches selection plans, not DOM results. |
-| [`Snapshot`](../src/nwsapi.mts#L4179) | Contains the document state and helpers used by compiled selectors. |
-| [`Version`](../src/nwsapi.mts#L4181) | Contains the engine version string. |
+| [`CFG`](../src/nwsapi.mts#L4180) | Contains the compiler syntax settings. |
+| [`Config`](../src/nwsapi.mts#L4206) | Contains the active options. Use `configure()` to change them. |
+| [`M_BODY`](../src/nwsapi.mts#L4183) | Contains the matching resolver body template. |
+| [`M_TEST`](../src/nwsapi.mts#L4187) | Contains the matching resolver test template. |
+| [`matchLambdas`](../src/nwsapi.mts#L4172) | Caches compiled matching functions, not DOM results. |
+| [`matchResolvers`](../src/nwsapi.mts#L4175) | Caches matching plans, not DOM results. |
+| [`N_BODY`](../src/nwsapi.mts#L4184) | Exposes the matching resolver body template. |
+| [`N_TEST`](../src/nwsapi.mts#L4188) | Contains the alternate resolver test template. |
+| [`Operators`](../src/nwsapi.mts#L4214) | Contains registered attribute operators. |
+| [`S_BODY`](../src/nwsapi.mts#L4182) | Contains the selection resolver body template. |
+| [`S_TEST`](../src/nwsapi.mts#L4186) | Contains the selection resolver test template. |
+| [`selectLambdas`](../src/nwsapi.mts#L4173) | Caches compiled selection functions, not DOM results. |
+| [`Selectors`](../src/nwsapi.mts#L4215) | Contains registered selector extensions. |
+| [`selectResolvers`](../src/nwsapi.mts#L4176) | Caches selection plans, not DOM results. |
+| [`Snapshot`](../src/nwsapi.mts#L4207) | Contains the document state and helpers used by compiled selectors. |
+| [`Version`](../src/nwsapi.mts#L4209) | Contains the engine version string. |
 
 </details>
 

--- a/src/nwsapi.mts
+++ b/src/nwsapi.mts
@@ -501,6 +501,7 @@
         NAMESPACE = root && root.namespaceURI
         Snapshot.doc = doc
         Snapshot.root = root
+        hoverWanted && trackHover()
       }
       return (Snapshot.from = context)
     },
@@ -2921,8 +2922,11 @@
               match[1] = match[1].toLowerCase()
               switch (match[1]) {
                 case 'hover':
-                  initEnv()
-                  source = 'if(e===s.HOVER){' + source + '}'
+                  trackHover()
+                  source =
+                    'if(e===s.HOVER||s.matchesNative(e,":hover")){' +
+                    source +
+                    '}'
                   break
                 case 'active':
                   source = 'if(e===s.doc.activeElement){' + source + '}'
@@ -3860,26 +3864,50 @@
     },
     // handlers needed for the :hover pseudo-class
     // track state change in browsers and headless
-    hoverInitialized = false,
-    initEnv = function () {
-      if (hoverInitialized) {
+    hoverWanted = false,
+    // null is uninitialized; undefined means WeakMap is unavailable.
+    hoverTracked = null,
+    hoverDoc,
+    hoverRecord,
+    hoverChanged = function (event) {
+      var targetDoc = event.target.ownerDocument || event.target,
+        record = hoverTracked
+          ? hoverTracked.get(targetDoc)
+          : targetDoc === hoverDoc
+            ? hoverRecord
+            : undefined
+      if (record) {
+        record.target = event.type == 'mouseover' ? event.target : undefined
+        if (targetDoc === doc) {
+          Snapshot.HOVER = record.target
+        }
+      }
+    },
+    trackHover = function () {
+      hoverWanted = true
+      if (!doc) {
         return
       }
-      doc.addEventListener(
-        'mouseover',
-        function (e) {
-          Snapshot.HOVER = e.target
-        },
-        true,
-      )
-      doc.addEventListener(
-        'mouseout',
-        function (e) {
-          Snapshot.HOVER = null
-        },
-        true,
-      )
-      hoverInitialized = true
+      if (hoverTracked === null) {
+        hoverTracked = createWeakMap()
+      }
+      var record = hoverTracked
+        ? hoverTracked.get(doc)
+        : hoverDoc === doc
+          ? hoverRecord
+          : undefined
+      if (!record) {
+        record = { target: undefined }
+        if (hoverTracked) {
+          hoverTracked.set(doc, record)
+        }
+        // Stable callbacks avoid duplicate listeners even without WeakMap.
+        doc.addEventListener('mouseover', hoverChanged, true)
+        doc.addEventListener('mouseout', hoverChanged, true)
+      }
+      hoverDoc = doc
+      hoverRecord = record
+      Snapshot.HOVER = record.target
     },
     // QSA placeholders to native references
     _closest,

--- a/test/repo/e2e/upstream/fixtures/hover-tracking.html
+++ b/test/repo/e2e/upstream/fixtures/hover-tracking.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>On-demand hover tracking</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+test(() => {
+  const doc = document.implementation.createHTMLDocument('host state');
+  doc.body.innerHTML = '<p></p>';
+  const target = doc.querySelector('p');
+  let hovered = true;
+  target.matches = selector => selector === ':hover' && hovered;
+  assert_array_equals(NW.Dom.select('p:hover', doc), [target]);
+  hovered = false;
+  assert_array_equals(NW.Dom.select('p:hover', doc), []);
+}, 'The first hover query consults state already known by the host matcher');
+test(() => {
+  const engine = NW.Dom;
+  const a = document.implementation.createHTMLDocument('a');
+  const b = document.implementation.createHTMLDocument('b');
+  a.body.innerHTML = '<p id="a"></p>';
+  b.body.innerHTML = '<p id="b"></p>';
+  const first = a.getElementById('a');
+  const second = b.getElementById('b');
+  const hovered = node => engine.select('p:hover', node.ownerDocument).includes(node);
+  assert_false(hovered(first));
+  first.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+  assert_true(hovered(first));
+  assert_false(hovered(second));
+  second.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+  first.dispatchEvent(new MouseEvent('mouseout', { bubbles: true }));
+  assert_true(hovered(second));
+  assert_false(hovered(first));
+  assert_true(hovered(second));
+  second.dispatchEvent(new MouseEvent('mouseout', { bubbles: true }));
+  assert_false(hovered(second));
+}, 'Hover tracking keeps independent state across document switches and background events');
+</script>

--- a/test/repo/e2e/upstream/manifest.mts
+++ b/test/repo/e2e/upstream/manifest.mts
@@ -47,6 +47,11 @@ export const manifest: Array<{
     install: false,
   },
   {
+    path: '/_repo/test/repo/e2e/upstream/fixtures/hover-tracking.html',
+    note: 'local WPT regression: lazy hover tracking and cross-document event isolation',
+    install: false,
+  },
+  {
     path: '/_repo/test/repo/e2e/upstream/fixtures/property-reads.html',
     note: 'local WPT regression: reflected classes, SVG base values, attribute fallbacks, and escaped IDs',
     install: false,

--- a/test/repo/unit/hover-tracking.test.mts
+++ b/test/repo/unit/hover-tracking.test.mts
@@ -1,22 +1,44 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import vm from 'node:vm'
+import { test, describe, afterEach } from 'vitest'
 import { JSDOM } from 'jsdom'
-import { describe, expect, test } from 'vitest'
 import factory from '../../../src/nwsapi.js'
+const nwsapiPath = new URL('../../../src/nwsapi.js', import.meta.url)
+const windows = []
+afterEach(() => {
+  for (const window of windows.splice(0)) {
+    window.close()
+  }
+})
 
 describe(':hover tracking is installed on demand', () => {
+  test('the first query can read hover state already known by the host', t => {
+    const { window } = new JSDOM('<p></p>')
+    t.onTestFinished(() => window.close())
+    const target = window.document.querySelector('p')!
+    let hovered = true
+    Reflect.set(
+      target,
+      'matches',
+      (selector: string) => selector === ':hover' && hovered,
+    )
+    const engine = factory(window)
+    assert.deepEqual(engine.select('p:hover'), [target])
+    hovered = false
+    assert.deepEqual(engine.select('p:hover'), [])
+  })
   function buildCounting(html) {
     const dom = new JSDOM(html)
     const { window } = dom
+    windows.push(window)
     const seen = []
     const original = window.document.addEventListener.bind(window.document)
     window.document.addEventListener = function (type, ...rest) {
       seen.push(type)
       return original(type, ...rest)
     }
-    const host = {
-      document: window.document,
-      DOMException: window.DOMException,
-    }
-    const NW = factory(host)
+    const NW = factory(window)
     return {
       window,
       document: window.document,
@@ -29,19 +51,20 @@ describe(':hover tracking is installed on demand', () => {
     const { document, NW, mouseListeners } = buildCounting(
       '<!doctype html><body><p id=p>x</p></body>',
     )
-    expect(mouseListeners()).toEqual([])
+    assert.deepEqual(mouseListeners(), [])
 
     NW.select('p', document)
-    expect(
+    assert.deepEqual(
       mouseListeners(),
+      [],
       'an ordinary selector must not install them',
-    ).toEqual([])
+    )
 
-    expect(NW.select('p:hover', document)).toEqual([])
-    expect(mouseListeners()).toEqual(['mouseover', 'mouseout'])
+    assert.deepEqual(NW.select('p:hover', document), [])
+    assert.deepEqual(mouseListeners(), ['mouseover', 'mouseout'])
     NW.match(':hover', document.body)
     NW.select('body:hover', document)
-    expect(mouseListeners()).toEqual(['mouseover', 'mouseout'])
+    assert.deepEqual(mouseListeners(), ['mouseover', 'mouseout'])
   })
 
   test(':hover still matches once tracking is installed', () => {
@@ -50,10 +73,85 @@ describe(':hover tracking is installed on demand', () => {
     )
     const target = document.getElementById('p')
 
-    expect(NW.match(':hover', target)).toBe(false)
+    assert.equal(NW.match(':hover', target), false)
     target.dispatchEvent(new window.MouseEvent('mouseover', { bubbles: true }))
-    expect(NW.match(':hover', target)).toBe(true)
+    assert.equal(NW.match(':hover', target), true)
     target.dispatchEvent(new window.MouseEvent('mouseout', { bubbles: true }))
-    expect(NW.match(':hover', target)).toBe(false)
+    assert.equal(NW.match(':hover', target), false)
+  })
+
+  test('document switches reuse listeners and isolate hover state', () => {
+    const a = buildCounting('<!doctype html><p id=a></p>')
+    const b = buildCounting('<!doctype html><p id=b></p>')
+    const first = a.document.getElementById('a')
+    const second = b.document.getElementById('b')
+    const hovered = node =>
+      a.NW.select('p:hover', node.ownerDocument).includes(node)
+    hovered(first)
+    first.dispatchEvent(new a.window.MouseEvent('mouseover', { bubbles: true }))
+    assert.equal(hovered(first), true)
+    assert.equal(hovered(second), false)
+    second.dispatchEvent(
+      new b.window.MouseEvent('mouseover', { bubbles: true }),
+    )
+    first.dispatchEvent(new a.window.MouseEvent('mouseout', { bubbles: true }))
+    assert.equal(
+      hovered(second),
+      true,
+      'background events do not clear active hover',
+    )
+    assert.equal(hovered(first), false)
+    assert.equal(hovered(second), true, 'switching restores the document state')
+    assert.deepEqual(a.mouseListeners(), ['mouseover', 'mouseout'])
+    assert.deepEqual(b.mouseListeners(), ['mouseover', 'mouseout'])
+  })
+
+  test('legacy tracking needs neither WeakMap nor WeakSet', () => {
+    const a = buildCounting('<!doctype html><p id=a></p>')
+    const b = buildCounting('<!doctype html><p id=b></p>')
+    const registered = new Set()
+    for (const item of [a, b]) {
+      const add = item.document.addEventListener.bind(item.document)
+      item.document.addEventListener = function (type, callback, ...rest) {
+        if (type === 'mouseover' || type === 'mouseout') {
+          registered.add(callback)
+        }
+        return add(type, callback, ...rest)
+      }
+    }
+    const context = {
+      module: {
+        exports: {} as (
+          host: Parameters<typeof factory>[0] & { DOMException: unknown },
+        ) => ReturnType<typeof factory>,
+      },
+      exports: {},
+      WeakMap: undefined,
+      WeakSet: undefined,
+    }
+    vm.runInNewContext(fs.readFileSync(nwsapiPath, 'utf8'), context)
+    const nw = context.module.exports({
+      document: a.document,
+      DOMException: a.window.DOMException,
+    })
+    nw.configure({ LEGACY: true })
+    for (let i = 0; i < 20; i++) {
+      const item = i % 2 ? a : b
+      const node = item.document.querySelector('p')
+      nw.select('p:hover', item.document)
+      node.dispatchEvent(
+        new item.window.MouseEvent('mouseover', { bubbles: true }),
+      )
+      assert.equal(nw.select('p:hover', item.document)[0], node)
+      node.dispatchEvent(
+        new item.window.MouseEvent('mouseout', { bubbles: true }),
+      )
+      assert.equal(nw.select('p:hover', item.document).length, 0)
+    }
+    assert.equal(
+      registered.size,
+      1,
+      'stable handler identity prevents duplicate listeners',
+    )
   })
 })


### PR DESCRIPTION
After an engine queries a second document, hover events from the first document can overwrite the active document's state. Keep lazy hover tracking per document, restore that state on document switches, and read native hover state that predates listener setup.

Use weak document records when WeakMap is available. Legacy hosts retain only the current document's record and reuse stable callbacks to avoid duplicate listeners. Preserve the lazy-registration and repeated-query assertions from #209, and add host-state, document-switching, background-event, and legacy-host regressions. The browser manifest retains the existing compound-negation fixture.

Validation after rebasing onto #206: 557 Node tests, 19 focused hover/descendant tests, and 56 browser tests pass. Formatting, lint, types, repository checks, and combined coverage pass. Combined coverage is 85.02% statements, 75.64% branches, 84.39% functions, and 83.83% lines. The packed-package check passed 22 tests before the rebase.
