### PR TITLE
Add shared Playwright test dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "url": "https://github.com/dperini/nwsapi.git"
   },
   "devDependencies": {
+    "@playwright/test": "1.62.1",
     "jsdom": "30.0.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
Add `@playwright/test` 1.62.1 as a shared development dependency. This is one commit adding one line to `package.json`.

Merged #211 already supplies jsdom 30.0.1 and the selector adapter. #178 now uses that adapter for the original reentry test, so no jsdom 26 alias is needed. Reference tests keep jsdom's default engine.

The 15 inherited Node tests pass. After this merges, dependent PRs can drop their repeated Playwright dependency additions. The refreshed #167 owns the lockfile and broader tooling.
