### PR TITLE
Add a jsdom selector-engine adapter

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,7 @@
 /*
 !dist/nwsapi.min.js
 !src/nwsapi.js
+!src/dom-selector.js
 !package.json
 !README.md
 !LICENSE

--- a/README.md
+++ b/README.md
@@ -31,6 +31,41 @@ $ npm install nwsapi
 NWSAPI currently supports browsers (as a global, `NW.Dom`) and headless environments (as a CommonJS module).
 
 
+## Using the jsdom adapter
+
+To use nwsapi ≥ 2.3.0 in jsdom ≥ 27, choose an override below. Replace `<version>`
+with the published nwsapi version you want to use.
+
+Add the adapter's `css-tree` peer dependency to `package.json`:
+
+```json
+{
+  "dependencies": {
+    "css-tree": "^3.2.1"
+  }
+}
+```
+
+- npm (`package.json`):
+
+  ```json
+  {
+    "overrides": {
+      "@asamuzakjp/dom-selector": "npm:nwsapi@<version>"
+    }
+  }
+  ```
+
+- pnpm (`pnpm-workspace.yaml`):
+
+  ```yaml
+  overrides:
+    '@asamuzakjp/dom-selector': 'npm:nwsapi@<version>'
+  ```
+
+Run `npm install` or `pnpm install`. jsdom will use nwsapi for queries and stylesheet
+matching. The existing nwsapi factory API and selector support are unchanged.
+
 ## Supported Selectors
 
 Here is a list of all the CSS2/CSS3/CSS4 [Supported selectors](https://github.com/dperini/nwsapi/wiki/CSS-supported-selectors).

--- a/package.json
+++ b/package.json
@@ -37,6 +37,17 @@
     "type": "git",
     "url": "https://github.com/dperini/nwsapi.git"
   },
+  "devDependencies": {
+    "jsdom": "30.0.1"
+  },
+  "peerDependencies": {
+    "css-tree": "^3.2.1"
+  },
+  "peerDependenciesMeta": {
+    "css-tree": {
+      "optional": true
+    }
+  },
   "scripts": {
     "lint": "eslint ./src/nwsapi.js"
   }

--- a/src/dom-selector.js
+++ b/src/dom-selector.js
@@ -1,0 +1,132 @@
+'use strict';
+
+const createNwsapi = require('./nwsapi.js');
+
+// jsdom passes implementation nodes in and expects public wrappers back.
+// css-tree is needed only by this adapter, for stylesheet specificity.
+class DOMSelector {
+  constructor(window, document = window.document, options = {}) {
+    this.window = window;
+    this.idlUtils = options.idlUtils;
+    this.document = this.wrap(document);
+    this.engine = createNwsapi({
+      document: this.document,
+      DOMException: window.DOMException
+    });
+    this.engine.configure({ LOGERRORS: false, VERBOSITY: true });
+  }
+
+  wrap(node) {
+    return this.idlUtils ? this.idlUtils.wrapperForImpl(node) : node;
+  }
+
+  run(method, selector, node, options, fallback, elementOnly = false) {
+    try {
+      node = this.wrap(node);
+      if (!node || (elementOnly ? node.nodeType !== 1 :
+        node.nodeType !== 1 && node.nodeType !== 9 && node.nodeType !== 11)) {
+        throw new this.window.TypeError('Expected a ' +
+          (elementOnly ? 'Element' : 'Document, DocumentFragment, or Element') + ' node');
+      }
+      return this.engine[method](selector, node);
+    } catch (error) {
+      if (options && options.noexcept) return fallback;
+      throw error;
+    }
+  }
+
+  matches(selector, node, options) {
+    return this.run('match', selector, node, options, false, true);
+  }
+
+  closest(selector, node, options) {
+    return this.run('closest', selector, node, options, null, true);
+  }
+
+  querySelector(selector, node, options) {
+    return this.run('first', selector, node, options, null);
+  }
+
+  querySelectorAll(selector, node, options) {
+    return this.run('select', selector, node, options, []);
+  }
+
+  clear(clearAll = false) {
+    // nwsapi caches compiled selectors, not matching results. DOM changes do
+    // not invalidate them. A full clear explicitly drops compiled selectors.
+    if (clearAll) {
+      this.engine.configure({}, true);
+      if (this.selectors) this.selectors.clear();
+    }
+  }
+
+  extractSubjects() {
+    // A wildcard keeps every stylesheet rule eligible. This is conservative:
+    // check() still does the matching, including escaped names and nested lists.
+    return [{ id: null, className: null, tag: null }];
+  }
+
+  supports(selector) {
+    if (typeof selector !== 'string') return false;
+    try {
+      this.engine.match(selector, this.document.createElement('div'));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  parse(selector) {
+    const selectors = this.selectors || (this.selectors = new Map());
+    let entry = selectors.get(selector);
+    if (!entry) {
+      const ast = this.css.parse(selector, { context: 'selectorList' });
+      const branches = [];
+      ast.children.forEach(branch => {
+        // jsdom does not compute styles for pseudo-elements. Keep them out of
+        // element specificity, even when another branch in the list matches.
+        let pseudoElement = false;
+        branch.children.forEach(part => {
+          if (part.type === 'PseudoElementSelector' ||
+            (part.type === 'PseudoClassSelector' &&
+             /^(before|after|first-line|first-letter)$/i.test(part.name))) {
+            pseudoElement = true;
+          }
+        });
+        if (!pseudoElement) {
+          branches.push({ ast: branch, selector: this.css.generate(branch) });
+        }
+      });
+      entry = { ast, branches };
+      // Bound syntax storage without caching DOM nodes or match results.
+      if (selectors.size >= 256) selectors.delete(selectors.keys().next().value);
+      selectors.set(selector, entry);
+    }
+    return entry;
+  }
+
+  check(selector, node) {
+    // Keep this outside the selector-error handler: a missing peer dependency
+    // must fail visibly rather than silently suppressing stylesheet matches.
+    const css = this.css || (this.css = require('css-tree'));
+    try {
+      node = this.wrap(node);
+      if (!node || node.nodeType !== 1) {
+        return { ast: null, match: false, pseudoElement: null };
+      }
+      const entry = this.parse(selector);
+      const matched = new css.List();
+      for (const branch of entry.branches) {
+        if (this.engine.match(branch.selector, node)) matched.appendData(branch.ast);
+      }
+      // Each result owns its list; checking another element cannot change it.
+      const ast = { ...entry.ast, children: matched };
+      return { ast, match: !matched.isEmpty, pseudoElement: null };
+    } catch {
+      // Invalid or unsupported stylesheet selectors do not break style reads.
+      return { ast: null, match: false, pseudoElement: null };
+    }
+  }
+}
+
+module.exports = DOMSelector;

--- a/src/nwsapi.js
+++ b/src/nwsapi.js
@@ -21,6 +21,9 @@
 
   if (typeof module == 'object' && typeof exports == 'object') {
     module.exports = factory;
+    Object.defineProperty(module.exports, 'DOMSelector', {
+      get: function() { return require('./dom-selector.js'); }
+    });
   } else if (typeof define == 'function' && define['amd']) {
     define(factory);
   } else {

--- a/test/jsdom-adapter-package.cjs
+++ b/test/jsdom-adapter-package.cjs
@@ -1,0 +1,31 @@
+'use strict';
+
+// Test the published file layout and npm override, not a patched module cache.
+const { execFileSync } = require('node:child_process');
+const { mkdtempSync, readdirSync, rmSync, writeFileSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+const { resolve } = require('node:path');
+const directory = mkdtempSync(resolve(tmpdir(), 'nwsapi-jsdom-adapter-'));
+const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+
+try {
+  execFileSync(npm, ['pack', '--ignore-scripts', '--pack-destination', directory], {
+    cwd: resolve(__dirname, '..'), stdio: 'inherit'
+  });
+  const tarball = readdirSync(directory).find(name => name.endsWith('.tgz'));
+  writeFileSync(resolve(directory, 'package.json'), JSON.stringify({
+    name: 'nwsapi-jsdom-adapter-test',
+    private: true,
+    dependencies: { jsdom: '30.0.1' },
+    overrides: { '@asamuzakjp/dom-selector': 'file:' + resolve(directory, tarball) }
+  }, null, 2));
+  execFileSync(npm, ['install', '--ignore-scripts', '--package-lock=false'], {
+    cwd: directory, stdio: 'inherit'
+  });
+  execFileSync(process.execPath, ['--test', resolve(__dirname, 'jsdom-adapter.test.cjs')], {
+    stdio: 'inherit',
+    env: { ...process.env, JSDOM_PACKAGE: resolve(directory, 'node_modules/jsdom/package.json') }
+  });
+} finally {
+  rmSync(directory, { recursive: true, force: true });
+}

--- a/test/jsdom-adapter.test.cjs
+++ b/test/jsdom-adapter.test.cjs
@@ -1,0 +1,206 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { createRequire } = require('node:module');
+const { test } = require('node:test');
+// The installed-package check runs this suite without substituting anything.
+const jsdomRequire = createRequire(process.env.JSDOM_PACKAGE || require.resolve('jsdom'));
+const factory = process.env.JSDOM_PACKAGE ? jsdomRequire('@asamuzakjp/dom-selector') :
+  require('../src/nwsapi.js');
+const { DOMSelector } = factory;
+if (!process.env.JSDOM_PACKAGE) {
+  const path = jsdomRequire.resolve('@asamuzakjp/dom-selector');
+  jsdomRequire(path);
+  require.cache[path].exports = factory;
+}
+if (process.env.JSDOM_PACKAGE) {
+  assert.equal(jsdomRequire('@asamuzakjp/dom-selector/package.json').name, 'nwsapi');
+}
+assert.equal(jsdomRequire('@asamuzakjp/dom-selector'), factory);
+const { JSDOM } = jsdomRequire('jsdom');
+
+function host(t, html = '<!doctype html><section><div class="item" id="one"></div><div class="item" id="two"></div></section>', options) {
+  const dom = new JSDOM(html, options);
+  t.after(() => dom.window.close());
+  return dom.window;
+}
+
+test('the callable factory and the DOMSelector export coexist', t => {
+  const window = host(t);
+  assert.equal(typeof factory, 'function');
+  assert.equal(typeof DOMSelector, 'function');
+  assert.equal(factory(window).first('.item', window.document).id, 'one');
+});
+
+test('real jsdom queries return wrappers and a static NodeList in document order', t => {
+  const window = host(t);
+  const document = window.document;
+  const nodes = document.querySelectorAll('#two, .item');
+  assert.ok(nodes instanceof window.NodeList);
+  assert.deepEqual(Array.from(nodes, n => n.id), ['one', 'two']);
+  assert.equal(document.querySelector('#one'), nodes[0]);
+  assert.ok(nodes[0] instanceof window.Element);
+  assert.equal(nodes[0].matches('.item'), true);
+  assert.equal(nodes[0].matches('#two'), false);
+  assert.equal(nodes[0].closest('section'), document.body.firstElementChild);
+  assert.equal(nodes[0].closest('article'), null);
+  nodes[0].remove();
+  assert.equal(nodes.length, 2);
+  assert.equal(document.querySelectorAll('.item').length, 1);
+});
+
+test('element, detached subtree, and fragment queries stay in their context', t => {
+  const window = host(t);
+  const document = window.document;
+  const section = document.body.firstElementChild;
+  assert.equal(section.querySelector('section'), null);
+  assert.deepEqual(Array.from(section.querySelectorAll(':scope > .item'), n => n.id), ['one', 'two']);
+  const fragment = document.createDocumentFragment();
+  const article = document.createElement('article');
+  article.innerHTML = '<b class="item"></b>';
+  fragment.append(article);
+  assert.equal(fragment.querySelector('.item'), article.firstElementChild);
+  assert.equal(fragment.querySelectorAll('b').length, 1);
+  assert.equal(article.firstElementChild.closest('article'), article);
+  assert.equal(article.matches('article'), true);
+});
+
+test('cached selectors see attribute, tree, and stylesheet mutations', t => {
+  const window = host(t, '<style>.on { color: red }</style><div></div>');
+  const document = window.document;
+  const node = document.body.firstElementChild;
+  assert.equal(document.querySelector('.on'), null);
+  node.className = 'on';
+  assert.equal(document.querySelector('.on'), node);
+  assert.equal(window.getComputedStyle(node).color, 'rgb(255, 0, 0)');
+  document.head.firstElementChild.textContent = '.on { color: blue }';
+  assert.equal(window.getComputedStyle(node).color, 'rgb(0, 0, 255)');
+  node.className = '';
+  assert.equal(document.querySelector('.on'), null);
+});
+
+test('CSS matching supplies specificity and excludes nonmatching list branches', t => {
+  const window = host(t, '<style>#missing, .item { color: red } section .item { color: blue } .item::before { color: green }</style><section><div class="item"></div></section>');
+  assert.equal(window.getComputedStyle(window.document.querySelector('.item')).color, 'rgb(0, 0, 255)');
+});
+
+test('DOM selector errors use the window SyntaxError and stylesheet errors do not escape', t => {
+  const window = host(t);
+  const document = window.document;
+  const node = document.body.firstElementChild;
+  for (const call of [() => document.querySelector('['), () => document.querySelectorAll('['),
+    () => node.matches('['), () => node.closest('[')]) {
+    assert.throws(call, error => error instanceof window.DOMException && error.name === 'SyntaxError');
+  }
+  const adapter = new DOMSelector(window);
+  assert.equal(adapter.check('[', node).match, false);
+  assert.equal(adapter.matches('[', node, { noexcept: true }), false);
+  assert.equal(adapter.supports('div'), true);
+  assert.equal(adapter.supports('['), false);
+  assert.equal(adapter.supports(undefined), false);
+  assert.throws(() => adapter.matches('div', document), window.TypeError);
+  adapter.clear();
+  adapter.clear(true);
+  assert.equal(adapter.querySelector('section', document), node);
+});
+
+test('separate documents and XML preserve ownership and case', t => {
+  const a = host(t);
+  const b = host(t);
+  assert.notEqual(a.document.querySelector('.item'), b.document.querySelector('.item'));
+  const xml = host(t, '<root><Item id="upper"/><item id="lower"/></root>', { contentType: 'application/xml' });
+  assert.equal(xml.document.querySelector('Item').id, 'upper');
+  assert.equal(xml.document.querySelector('item').id, 'lower');
+});
+
+test('DOM-only calls leave the CSS parser and syntax cache unloaded', t => {
+  const window = host(t);
+  const adapter = new DOMSelector(window);
+  const document = window.document;
+  const node = document.body.firstElementChild;
+  adapter.querySelector('section', document);
+  adapter.querySelectorAll('div', node);
+  adapter.matches('section', node);
+  adapter.closest('section', node);
+  adapter.supports('section');
+  adapter.extractSubjects('section');
+  adapter.clear(true);
+  assert.equal(adapter.css, undefined);
+  assert.equal(adapter.selectors, undefined);
+  assert.equal(adapter.check('section', node).match, true);
+  assert.equal(typeof adapter.css.parse, 'function');
+  assert.equal(adapter.selectors.size, 1);
+});
+
+test('stylesheet checks reuse syntax but not match results or result lists', t => {
+  const window = host(t);
+  const adapter = new DOMSelector(window);
+  const node = window.document.body.firstElementChild;
+  adapter.check('section', node);
+  const css = adapter.css;
+  let parses = 0, generations = 0;
+  adapter.css = {
+    ...css,
+    parse(...args) { parses++; return css.parse(...args); },
+    generate(...args) { generations++; return css.generate(...args); }
+  };
+  const selector = '#changed, section';
+  const first = adapter.check(selector, node);
+  assert.equal(first.ast.children.size, 1);
+  node.id = 'changed';
+  adapter.clear();
+  const second = adapter.check(selector, node);
+  assert.equal(second.ast.children.size, 2);
+  assert.equal(first.ast.children.size, 1);
+  assert.equal(parses, 1);
+  assert.equal(generations, 2);
+  adapter.clear(true);
+  adapter.check(selector, node);
+  assert.equal(parses, 2);
+  assert.equal(generations, 4);
+});
+
+test('stylesheet syntax cache stays bounded and evicted selectors still work', t => {
+  const window = host(t);
+  const adapter = new DOMSelector(window);
+  const node = window.document.body.firstElementChild;
+  for (let i = 0; i < 300; i++) adapter.check('.item' + i, node);
+  assert.equal(adapter.selectors.size, 256);
+  assert.equal(adapter.selectors.has('.item0'), false);
+  node.className = 'item0';
+  assert.equal(adapter.check('.item0', node).match, true);
+  assert.equal(adapter.selectors.size, 256);
+});
+
+test('a missing CSS peer only fails when stylesheet matching needs it', t => {
+  const window = host(t);
+  const Module = require('node:module');
+  const entry = process.env.JSDOM_PACKAGE ? jsdomRequire.resolve('@asamuzakjp/dom-selector') :
+    require.resolve('../src/nwsapi.js');
+  const path = createRequire(entry).resolve('./dom-selector.js');
+  const original = Module.prototype.require;
+  let loads = 0, factoryLoads = 0;
+  const missing = new Error('Missing css-tree peer');
+  Module.prototype.require = function(name) {
+    if (this.filename === path && name === './nwsapi.js') factoryLoads++;
+    if (this.filename === path && name === 'css-tree') {
+      loads++;
+      throw missing;
+    }
+    return original.apply(this, arguments);
+  };
+  try {
+    const adapter = new DOMSelector(window);
+    const second = new DOMSelector(window);
+    assert.notEqual(adapter.engine, second.engine);
+    assert.equal(factoryLoads, 0, 'instances reuse the captured factory without requiring it again');
+    const document = window.document;
+    assert.equal(adapter.querySelector('section', document), document.body.firstElementChild);
+    assert.equal(adapter.matches('section', document.body.firstElementChild), true);
+    assert.equal(loads, 0);
+    assert.throws(() => adapter.check('section', document.body.firstElementChild), error => error === missing);
+    assert.equal(loads, 1);
+  } finally {
+    Module.prototype.require = original;
+  }
+});


### PR DESCRIPTION
## Use nwsapi inside jsdom 30

Add a `DOMSelector` export alongside the existing CommonJS factory. It lets npm replace jsdom 30's `@asamuzakjp/dom-selector` dependency with nwsapi without patching jsdom or its DOM prototypes.

The adapter converts jsdom's internal nodes to public DOM nodes and routes queries, matches, and closest calls through nwsapi. It also supplies the CSS syntax trees that jsdom needs for stylesheet specificity. `css-tree` is an optional peer dependency, already supplied by jsdom 30; ordinary nwsapi callers do not load it.

The adapter loads `css-tree` only on the first stylesheet `check()`. DOM-only calls do not request it. A 256-entry cache reuses parsed selectors and generated branch text, never match results. DOM mutations stay visible, and `clear(true)` drops the syntax cache. The adapter checks all stylesheet rules without a subject prefilter. Existing selector bugs remain nwsapi's responsibility; this does not replace #178 or the other fixes.

## Tests

On Node 26.5.0, all 11 integration tests pass both locally and through a fresh npm install of the packed adapter. Coverage includes DOM wrappers, static NodeLists, ordering, scoped and detached queries, fragments, XML, mutations, errors, stylesheet specificity, lazy loading, missing peers, and bounded syntax caching.

A local microbenchmark of 10,000 warm stylesheet checks fell from 28.54 ms to 3.00 ms (median of seven runs). This measures repeated syntax reuse, not end-to-end jsdom performance. jsdom can also load `css-tree` independently.

Run `node --test test/jsdom-adapter.test.cjs` for local checks. Run `node test/jsdom-adapter-package.cjs` for the real npm override check. The latter packs this checkout, installs jsdom 30.0.1 in a temporary consumer, overrides its selector dependency with that tarball, and runs the same suite without a module-cache substitution.

The original reentry path also remains observable through this installed adapter. Across 300 real `Element.matches()` calls, master reaches the depth-21 safety limit. With #178's factory, the same test creates one engine, makes 301 engine calls, reaches depth two, and never hits the limit. We can therefore move reentry coverage to jsdom 30 and remove the jsdom 26 alias from #210.

## Scope

This is one commit targeting master. The engine change is only the lazy CommonJS export. The adapter, tests, package inclusion, optional peer declaration, and usage documentation are separate from selector fixes. The README shows an override to the published npm package, using the version of a future release containing the adapter. The existing npm release does not yet contain it. The package test uses a temporary tarball only to verify the adapter before publication.
